### PR TITLE
Make layout responsive with mobile stack overlay

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -9,6 +9,10 @@
   --btfw-border: rgba(255,255,255,.08);
   --btfw-card-bg: rgba(20,24,34,.92);
   --btfw-radius: 12px;
+  --btfw-chat-min: 320px;
+  --btfw-chat-max: 30vw;
+  --btfw-split-width: 8px;
+  --btfw-vertical-video: 40vh;
 }
 
 *, *::before, *::after { box-sizing: border-box; }
@@ -16,7 +20,8 @@
 /* ---------- Main 2-column grid: left content + splitter + right chat ---------- */
 #btfw-grid{
   display: grid;
-  grid-template-columns: minmax(640px,1fr) 8px minmax(320px,26vw);
+  grid-template-columns: minmax(520px,1fr) var(--btfw-split-width) minmax(var(--btfw-chat-min),var(--btfw-chat-max));
+  grid-template-areas: "video split chat";
   grid-column-gap: var(--btfw-gap);
   grid-row-gap: var(--btfw-gap);
   margin-top: calc(var(--btfw-top) + var(--btfw-gap));
@@ -24,13 +29,15 @@
   min-height: calc(100vh - var(--btfw-top) - var(--btfw-gap)); /* Ensure full height */
 }
 
-#btfw-leftpad{ 
-  min-width: 0; 
+#btfw-leftpad{
+  grid-area: video;
+  min-width: 0;
   display: flex;
   flex-direction: column;
 }
 
 #btfw-chatcol{
+  grid-area: chat;
   position: sticky;
   top: calc(var(--btfw-top) + var(--btfw-gap)); /* Account for grid padding */
   height: calc(100vh - var(--btfw-top) - var(--btfw-gap) * 2); /* Account for both top and grid padding */
@@ -42,11 +49,69 @@
 
 /* Visual splitter (no drag in CSS; JS can attach drag later) */
 #btfw-vsplit{
-  width: 8px;
+  grid-area: split;
+  width: var(--btfw-split-width);
   background: linear-gradient(90deg, transparent, rgba(255,255,255,.08), transparent);
   border-radius: 4px;
   cursor: col-resize;
   align-self: stretch; /* Ensure splitter takes full height */
+}
+
+/* Allow swapping chat/video positions on desktop */
+#btfw-grid.btfw-grid--chat-left{
+  grid-template-columns: minmax(var(--btfw-chat-min),var(--btfw-chat-max)) var(--btfw-split-width) minmax(520px,1fr);
+  grid-template-areas: "chat split video";
+}
+
+#btfw-grid.btfw-grid--chat-right{
+  grid-template-columns: minmax(520px,1fr) var(--btfw-split-width) minmax(var(--btfw-chat-min),var(--btfw-chat-max));
+  grid-template-areas: "video split chat";
+}
+
+/* Vertical (mobile) layout with video stacked above chat */
+#btfw-grid.btfw-grid--vertical{
+  grid-template-columns: 1fr;
+  grid-template-areas:
+    "video"
+    "chat";
+  grid-template-rows: var(--btfw-vertical-video) 1fr;
+  grid-row-gap: var(--btfw-gap);
+  min-height: 0;
+  height: calc(100vh - var(--btfw-top) - var(--btfw-gap));
+}
+
+#btfw-grid.btfw-grid--vertical #btfw-vsplit{ display:none; }
+
+#btfw-grid.btfw-grid--vertical #btfw-leftpad{
+  min-height: 220px;
+  max-height: var(--btfw-vertical-video);
+  height: var(--btfw-vertical-video);
+  position: relative;
+}
+
+#btfw-grid.btfw-grid--vertical #videowrap{
+  flex: 1 1 auto;
+  min-height: 0;
+  height: 100%;
+}
+
+#btfw-grid.btfw-grid--vertical #videowrap iframe{
+  width: 100%;
+  height: 100%;
+  aspect-ratio: unset;
+}
+
+#btfw-grid.btfw-grid--vertical #btfw-chatcol{
+  position: relative;
+  top: 0;
+  height: 100%;
+  min-height: 0;
+}
+
+#btfw-grid.btfw-grid--vertical #chatwrap{
+  flex: 1 1 auto;
+  min-height: 0;
+  height: 100%;
 }
 
 /* ---------- Content Stack under video ---------- */

--- a/css/chat.css
+++ b/css/chat.css
@@ -24,6 +24,7 @@
   display:flex;
   align-items:center;
   justify-content:space-between;
+  gap: 10px;
   padding:8px 10px;
   margin:0 0 8px 0;
   border:1px solid var(--btfw-border);
@@ -31,11 +32,37 @@
   flex-shrink: 0; /* Don't shrink these bars */
 }
 
+.btfw-chat-topbar-left{
+  display:flex;
+  align-items:center;
+  gap: 10px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.btfw-chat-topbar-actions{
+  display:flex;
+  align-items:center;
+  gap: 6px;
+  flex: 0 0 auto;
+}
+
 #btfw-nowplaying-slot{
   font-weight: 600;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+#btfw-mobile-modules-toggle{
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 10px;
+}
+
+#btfw-grid.btfw-grid--vertical #btfw-mobile-modules-toggle{
+  display: inline-flex;
 }
 
 /* Scrollable messages - this should take all remaining space */

--- a/css/mobile.css
+++ b/css/mobile.css
@@ -6,20 +6,98 @@
 
 /* --------- Tablet & down (<= 1100px): stack columns, unstick chat --------- */
 @media (max-width: 1100px){
-  #btfw-grid{
-    grid-template-columns: 1fr;
-    grid-row-gap: 10px;
+  #btfw-grid.btfw-grid--vertical{
     padding: 0 8px;
     margin-top: calc(var(--btfw-top,48px) + 8px);
+    height: calc(100vh - var(--btfw-top,48px) - 8px);
   }
-  #btfw-vsplit{ display:none; }
-  #btfw-chatcol{
-    position: relative;
-    top: auto;
+
+  #btfw-grid.btfw-grid--vertical #btfw-chatcol{
     height: auto;
     min-height: 420px;
   }
 }
+
+/* Mobile module drawer (shown when layout switches to vertical) */
+#btfw-mobile-stack{
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: flex-start;
+  justify-content: center;
+  z-index: 7000;
+  padding: calc(var(--btfw-top,48px) + 10px) 16px 18px;
+  overflow-y: auto;
+}
+
+#btfw-mobile-stack::before{
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: rgba(7,10,16,0.72);
+  backdrop-filter: blur(10px);
+}
+
+#btfw-mobile-stack .btfw-mobile-stack__panel{
+  position: relative;
+  width: min(560px, 94vw);
+  max-height: calc(100vh - var(--btfw-top,48px) - 40px);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(255,255,255,0.1);
+  background: rgba(20,24,34,0.94);
+  box-shadow: 0 22px 48px rgba(4,6,12,0.6);
+  overflow: hidden;
+}
+
+#btfw-mobile-stack .btfw-mobile-stack__header{
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+#btfw-mobile-stack .btfw-mobile-stack__title{
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+#btfw-mobile-stack .btfw-mobile-stack__close{
+  border: 0;
+  background: rgba(255,255,255,0.08);
+  color: #fff;
+  border-radius: 10px;
+  padding: 6px 10px;
+  font-size: 0.95rem;
+  cursor: pointer;
+}
+
+#btfw-mobile-stack .btfw-mobile-stack__close:hover{
+  background: rgba(255,255,255,0.16);
+}
+
+#btfw-mobile-stack .btfw-mobile-stack__body{
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--btfw-gap, 10px);
+}
+
+#btfw-mobile-stack .btfw-stack{
+  width: 100%;
+}
+
+#btfw-mobile-stack.btfw-mobile-stack--open{ display:flex; }
+
+body.btfw-mobile-stack-open{ overflow: hidden; }
+
+body:not(.btfw-mobile-stack-enabled) #btfw-mobile-stack{ display:none !important; }
 
 /* --------- Phones (<= 768px): larger touch targets, overlay sizes ---------- */
 @media (max-width: 768px){

--- a/modules/feature-chat.js
+++ b/modules/feature-chat.js
@@ -197,14 +197,45 @@ function watchForStrayButtons(){
     if (!top) {
       top = document.createElement("div");
       top.className = "btfw-chat-topbar";
-      top.innerHTML = '<div class="btfw-chat-title" id="btfw-nowplaying-slot"></div>';
+      top.innerHTML = `
+        <div class="btfw-chat-topbar-left">
+          <div class="btfw-chat-title" id="btfw-nowplaying-slot"></div>
+        </div>
+        <div class="btfw-chat-topbar-actions" id="btfw-chat-topbar-actions"></div>
+      `;
       cw.prepend(top);
     }
-    if (!top.querySelector("#btfw-nowplaying-slot")) {
+
+    let left = top.querySelector(".btfw-chat-topbar-left");
+    if (!left) {
+      left = document.createElement("div");
+      left.className = "btfw-chat-topbar-left";
+      top.prepend(left);
+    }
+
+    if (!left.querySelector("#btfw-nowplaying-slot")) {
       const slot = document.createElement("div");
       slot.id = "btfw-nowplaying-slot";
       slot.className = "btfw-chat-title";
-      top.appendChild(slot);
+      left.appendChild(slot);
+    }
+
+    let topActions = top.querySelector("#btfw-chat-topbar-actions");
+    if (!topActions) {
+      topActions = document.createElement("div");
+      topActions.id = "btfw-chat-topbar-actions";
+      topActions.className = "btfw-chat-topbar-actions";
+      top.appendChild(topActions);
+    }
+
+    if (!topActions.querySelector("#btfw-mobile-modules-toggle")) {
+      const btn = document.createElement("button");
+      btn.id = "btfw-mobile-modules-toggle";
+      btn.className = "button is-dark is-small btfw-chatbtn";
+      btn.title = "Modules";
+      btn.setAttribute("aria-label", "Toggle modules stack");
+      btn.innerHTML = '<i class="fa fa-bars"></i>';
+      topActions.appendChild(btn);
     }
 
     // Bottom bar + actions
@@ -269,7 +300,15 @@ function watchForStrayButtons(){
       controls.classList.add("btfw-controls-row");
       bottom.after(controls);
     }
-	normalizeChatActionButtons();
+    normalizeChatActionButtons();
+
+    document.dispatchEvent(new CustomEvent("btfw:chat:barsReady", {
+      detail: {
+        topbar: top,
+        bottombar: bottom,
+        actions: topActions
+      }
+    }));
   }
 
   /* ---------------- Usercount to bottom-right & remove #chatheader ---------------- */

--- a/modules/feature-layout.js
+++ b/modules/feature-layout.js
@@ -1,5 +1,190 @@
 BTFW.define("feature:layout", ["feature:styleCore","feature:bulma"], async ({}) => {
   const SPLIT_KEY = "btfw:grid:leftPx";
+  const CHAT_SIDE_KEY = "btfw:layout:chatSide";
+  const MOBILE_STACK_ID = "btfw-mobile-stack";
+  const VIDEO_MIN_PX = 520;
+  const DEFAULT_VIDEO_TARGET = 680;
+  const CHAT_MIN_PX = 360;
+  const WIDTH_BUFFER = 120;
+
+  let videoColumnPx = null;
+  let chatSidePref = "right";
+  let isVertical = false;
+  let mobileToggleEl = null;
+
+  function getStoredChatSide(){
+    try {
+      const stored = localStorage.getItem(CHAT_SIDE_KEY);
+      return stored === "left" ? "left" : "right";
+    } catch (_) {
+      return "right";
+    }
+  }
+
+  function loadVideoColumnWidth(){
+    try {
+      const saved = parseInt(localStorage.getItem(SPLIT_KEY) || "", 10);
+      if (!isNaN(saved) && saved >= VIDEO_MIN_PX) {
+        videoColumnPx = saved;
+      }
+    } catch (_) {
+      videoColumnPx = null;
+    }
+  }
+
+  function applyColumnTemplate(){
+    const grid = document.getElementById("btfw-grid");
+    if (!grid) return;
+
+    if (isVertical) {
+      grid.style.gridTemplateColumns = "";
+      grid.classList.remove("btfw-grid--chat-left", "btfw-grid--chat-right");
+      return;
+    }
+
+    const videoSegment = videoColumnPx
+      ? `${Math.max(videoColumnPx, VIDEO_MIN_PX)}px`
+      : `minmax(${VIDEO_MIN_PX}px, 1fr)`;
+    const chatSegment = "minmax(var(--btfw-chat-min, 320px), 1fr)";
+    const template = chatSidePref === "left"
+      ? `${chatSegment} var(--btfw-split-width, 8px) ${videoSegment}`
+      : `${videoSegment} var(--btfw-split-width, 8px) ${chatSegment}`;
+
+    grid.style.gridTemplateColumns = template;
+    grid.classList.toggle("btfw-grid--chat-left", chatSidePref === "left");
+    grid.classList.toggle("btfw-grid--chat-right", chatSidePref !== "left");
+  }
+
+  function setVideoColumnWidth(px){
+    if (!Number.isFinite(px)) return;
+    const width = Math.max(px, VIDEO_MIN_PX);
+    videoColumnPx = width;
+    try { localStorage.setItem(SPLIT_KEY, String(width)); } catch (_) {}
+    applyColumnTemplate();
+  }
+
+  function computeThreshold(){
+    const target = Math.max(videoColumnPx || DEFAULT_VIDEO_TARGET, VIDEO_MIN_PX);
+    return target + CHAT_MIN_PX + WIDTH_BUFFER;
+  }
+
+  function ensureMobileStackShell(){
+    let shell = document.getElementById(MOBILE_STACK_ID);
+    if (!shell) {
+      shell = document.createElement("div");
+      shell.id = MOBILE_STACK_ID;
+      shell.className = "btfw-mobile-stack";
+      shell.innerHTML = `
+        <div class="btfw-mobile-stack__panel" role="dialog" aria-modal="true" aria-labelledby="btfw-mobile-stack-title">
+          <div class="btfw-mobile-stack__header">
+            <span class="btfw-mobile-stack__title" id="btfw-mobile-stack-title">Modules</span>
+            <button type="button" class="btfw-mobile-stack__close" aria-label="Close modules">&times;</button>
+          </div>
+          <div class="btfw-mobile-stack__body"></div>
+        </div>
+      `;
+      document.body.appendChild(shell);
+
+      shell.addEventListener("click", (ev) => {
+        if (ev.target === shell) setMobileStackOpen(false);
+      });
+      const closeBtn = shell.querySelector(".btfw-mobile-stack__close");
+      if (closeBtn) closeBtn.addEventListener("click", () => setMobileStackOpen(false));
+
+      if (!document._btfwMobileStackEsc) {
+        document._btfwMobileStackEsc = true;
+        document.addEventListener("keydown", (ev) => {
+          if (ev.key === "Escape") setMobileStackOpen(false);
+        });
+      }
+    }
+    return shell;
+  }
+
+  function setMobileStackOpen(open){
+    const shell = ensureMobileStackShell();
+    const allow = !!open && isVertical;
+    shell.classList.toggle("btfw-mobile-stack--open", allow);
+    if (document.body) {
+      document.body.classList.toggle("btfw-mobile-stack-open", allow);
+    }
+    const toggle = document.getElementById("btfw-mobile-modules-toggle");
+    if (toggle) toggle.setAttribute("aria-expanded", allow ? "true" : "false");
+  }
+
+  function moveStackToOverlay(){
+    if (!isVertical) return;
+    const stack = document.getElementById("btfw-stack");
+    if (!stack) return;
+    const shell = ensureMobileStackShell();
+    const body = shell.querySelector(".btfw-mobile-stack__body");
+    if (body && stack.parentElement !== body) {
+      body.appendChild(stack);
+    }
+  }
+
+  function restoreStackFromOverlay(){
+    const stack = document.getElementById("btfw-stack");
+    if (!stack) return;
+    const left = document.getElementById("btfw-leftpad");
+    if (!left) return;
+    if (stack.parentElement === left) return;
+    const video = document.getElementById("videowrap");
+    if (video && video.parentElement === left) {
+      if (video.nextSibling) {
+        left.insertBefore(stack, video.nextSibling);
+      } else {
+        left.appendChild(stack);
+      }
+    } else {
+      left.appendChild(stack);
+    }
+  }
+
+  function wireMobileToggle(){
+    const toggle = document.getElementById("btfw-mobile-modules-toggle");
+    if (!toggle || toggle === mobileToggleEl) return;
+    mobileToggleEl = toggle;
+    toggle.setAttribute("aria-expanded", "false");
+    toggle.setAttribute("aria-haspopup", "dialog");
+    toggle.addEventListener("click", (ev) => {
+      ev.preventDefault();
+      if (!isVertical) return;
+      const shell = ensureMobileStackShell();
+      const open = !shell.classList.contains("btfw-mobile-stack--open");
+      if (open) moveStackToOverlay();
+      setMobileStackOpen(open);
+    });
+  }
+
+  function updateResponsiveLayout(){
+    const grid = document.getElementById("btfw-grid");
+    if (!grid) return;
+
+    wireMobileToggle();
+
+    const shouldVertical = window.innerWidth < computeThreshold();
+    if (shouldVertical !== isVertical) {
+      isVertical = shouldVertical;
+      grid.classList.toggle("btfw-grid--vertical", shouldVertical);
+      if (document.body) {
+        document.body.classList.toggle("btfw-mobile-stack-enabled", shouldVertical);
+      }
+
+      if (shouldVertical) {
+        moveStackToOverlay();
+      } else {
+        setMobileStackOpen(false);
+        restoreStackFromOverlay();
+      }
+    } else if (!shouldVertical) {
+      restoreStackFromOverlay();
+    } else {
+      moveStackToOverlay();
+    }
+
+    applyColumnTemplate();
+  }
   
   function setTop(){
     const header = document.querySelector(".navbar, #nav-collapsible, #navbar, .navbar-fixed-top");
@@ -20,10 +205,7 @@ BTFW.define("feature:layout", ["feature:styleCore","feature:bulma"], async ({}) 
   function makeResizable() {
     const grid = document.getElementById("btfw-grid");
     const splitter = document.getElementById("btfw-vsplit");
-    const left = document.getElementById("btfw-leftpad");
-    const right = document.getElementById("btfw-chatcol");
-
-    if (!grid || !splitter || !left || !right) {
+    if (!grid || !splitter) {
       console.warn("[BTFW] Resizer elements not found.");
       return;
     }
@@ -31,7 +213,9 @@ BTFW.define("feature:layout", ["feature:styleCore","feature:bulma"], async ({}) 
     let isResizing = false;
 
     splitter.addEventListener("mousedown", (e) => {
+      if (isVertical) return;
       isResizing = true;
+      e.preventDefault();
       // Add a class to the body to prevent text selection during drag
       document.body.classList.add("btfw-resizing");
 
@@ -40,27 +224,37 @@ BTFW.define("feature:layout", ["feature:styleCore","feature:bulma"], async ({}) 
     });
 
     function handleMouseMove(e) {
-      if (!isResizing) return;
+      if (!isResizing || isVertical) return;
 
-      // Calculate the new column widths based on mouse position
       const gridRect = grid.getBoundingClientRect();
-      const newLeftWidth = e.clientX - gridRect.left;
-      
-      // Set a min-width to prevent columns from collapsing
-      if (newLeftWidth < 400 || (gridRect.width - newLeftWidth) < 320) {
-          return;
+      const splitRect = splitter.getBoundingClientRect();
+      const splitWidth = splitRect.width || parseFloat(getComputedStyle(splitter).width) || 6;
+
+      let newVideoWidth;
+
+      if (chatSidePref === "left") {
+        const pointerX = e.clientX - gridRect.left;
+        const chatWidth = Math.max(pointerX - splitWidth / 2, 0);
+        const available = gridRect.width - chatWidth - splitWidth;
+        if (available < VIDEO_MIN_PX || chatWidth < CHAT_MIN_PX) return;
+        newVideoWidth = available;
+      } else {
+        newVideoWidth = e.clientX - gridRect.left;
+        const chatWidthCandidate = gridRect.width - newVideoWidth - splitWidth;
+        if (newVideoWidth < VIDEO_MIN_PX || chatWidthCandidate < CHAT_MIN_PX) return;
       }
 
-      // Update the grid-template-columns style directly
-      grid.style.gridTemplateColumns = `${newLeftWidth}px 5px 1fr`;
-      try { localStorage.setItem(SPLIT_KEY, String(newLeftWidth)); } catch(e) {}
+      if (!Number.isFinite(newVideoWidth)) return;
+      setVideoColumnWidth(newVideoWidth);
     }
 
     function stopResize() {
+      if (!isResizing) return;
       isResizing = false;
       document.body.classList.remove("btfw-resizing");
       document.removeEventListener("mousemove", handleMouseMove);
       document.removeEventListener("mouseup", stopResize);
+      updateResponsiveLayout();
     }
   }
 
@@ -99,42 +293,34 @@ BTFW.define("feature:layout", ["feature:styleCore","feature:bulma"], async ({}) 
     const q=document.getElementById("playlistrow")||document.getElementById("playlistwrap")||document.getElementById("queuecontainer");
     
     if(!document.getElementById("btfw-grid")){
-      const grid=document.createElement("div"); 
+      const grid=document.createElement("div");
       grid.id="btfw-grid";
-      
-      const left=document.createElement("div"); 
+
+      const left=document.createElement("div");
       left.id="btfw-leftpad";
-      
-      const right=document.createElement("aside"); 
+
+      const right=document.createElement("aside");
       right.id="btfw-chatcol";
-      
-      if(v) left.appendChild(v); 
-      if(q) left.appendChild(q); 
+
+      if(v) left.appendChild(v);
+      if(q) left.appendChild(q);
       if(c) right.appendChild(c);
-      
-      const split=document.createElement("div"); 
+
+      const split=document.createElement("div");
       split.id="btfw-vsplit";
-      
-      grid.appendChild(left); 
-      grid.appendChild(split); 
+
+      grid.appendChild(left);
+      grid.appendChild(split);
       grid.appendChild(right);
-      
+
       // Insert grid but keep it hidden until properly sized
       grid.style.opacity = '0';
       wrap.prepend(grid);
-      
-      // Restore saved split position
-      try {
-        const saved = parseInt(localStorage.getItem(SPLIT_KEY) || "", 10);
-        if (!isNaN(saved) && saved >= 400) {
-          grid.style.gridTemplateColumns = `${saved}px 5px 1fr`;
-        }
-      } catch (e) {}
-      
+
     } else {
-      const left=document.getElementById("btfw-leftpad"); 
+      const left=document.getElementById("btfw-leftpad");
       const right=document.getElementById("btfw-chatcol");
-      const v=document.getElementById("videowrap"); 
+      const v=document.getElementById("videowrap");
       const c=document.getElementById("chatwrap"); 
       const q=document.getElementById("playlistrow")||document.getElementById("playlistwrap")||document.getElementById("queuecontainer");
       
@@ -142,7 +328,16 @@ BTFW.define("feature:layout", ["feature:styleCore","feature:bulma"], async ({}) 
       if(q && !left.contains(q)) left.appendChild(q); 
       if(c && !right.contains(c)) right.appendChild(c);
     }
-    
+
+    const leftpadWatch = document.getElementById("btfw-leftpad");
+    if (leftpadWatch && !leftpadWatch._btfwStackWatch) {
+      const obs = new MutationObserver(() => {
+        if (isVertical) moveStackToOverlay();
+      });
+      obs.observe(leftpadWatch, { childList: true });
+      leftpadWatch._btfwStackWatch = obs;
+    }
+
     ["videowrap","playlistrow","playlistwrap","queuecontainer","queue","plmeta","chatwrap"].forEach(id=>stripDeep(document.getElementById(id)));
     moveCurrent();
   }
@@ -154,13 +349,18 @@ BTFW.define("feature:layout", ["feature:styleCore","feature:bulma"], async ({}) 
       grid.classList.add("btfw-loaded");
       grid.style.opacity = '1';
     }
+    updateResponsiveLayout();
     document.dispatchEvent(new CustomEvent("btfw:layoutReady"));
   }
 
   function init() {
     ensureShell();
+    loadVideoColumnWidth();
+    chatSidePref = getStoredChatSide();
+    applyColumnTemplate();
     setTop();
-    
+    updateResponsiveLayout();
+
     // Set up a more robust layout finalization
     const finalizeLayout = () => {
       setTop(); // Recalculate in case navbar mounted late
@@ -185,15 +385,31 @@ BTFW.define("feature:layout", ["feature:styleCore","feature:bulma"], async ({}) 
     if (navbar) {
       const resizeObserver = new ResizeObserver(() => {
         setTimeout(setTop, 0);
+        setTimeout(updateResponsiveLayout, 0);
       });
       resizeObserver.observe(navbar);
     }
 
     // Watch for window resize
     window.addEventListener('resize', () => {
-      setTimeout(setTop, 0);
+      setTimeout(() => {
+        setTop();
+        updateResponsiveLayout();
+      }, 0);
     });
   }
+
+  document.addEventListener("btfw:layout:chatSideChanged", (ev) => {
+    const side = ev && ev.detail && ev.detail.side === "left" ? "left" : "right";
+    chatSidePref = side;
+    applyColumnTemplate();
+    updateResponsiveLayout();
+  });
+
+  document.addEventListener("btfw:chat:barsReady", () => {
+    wireMobileToggle();
+    if (isVertical) moveStackToOverlay();
+  });
 
   if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", init);

--- a/modules/feature-theme-settings.js
+++ b/modules/feature-theme-settings.js
@@ -12,7 +12,8 @@ BTFW.define("feature:themeSettings", [], async () => {
     gifAutoplay : "btfw:chat:gifAutoplay",    // "1" | "0"
     pipEnabled  : "btfw:pip:enabled",         // "1" | "0"
     localSubs   : "btfw:video:localsubs",     // "1" | "0"
-    billcastEnabled: "btfw:billcast:enabled"  // "1" | "0"
+    billcastEnabled: "btfw:billcast:enabled", // "1" | "0"
+    layoutSide  : "btfw:layout:chatSide"      // "left" | "right"
   };
 
   // storage helpers
@@ -139,6 +140,18 @@ BTFW.define("feature:themeSettings", [], async () => {
               <div class="content">
                 <h4>Video</h4>
                 <div class="field">
+                  <label class="label">Desktop layout</label>
+                  <div class="control">
+                    <label class="radio" style="margin-right:12px;">
+                      <input type="radio" name="btfw-chat-side" value="right"> Video left, chat right
+                    </label>
+                    <label class="radio">
+                      <input type="radio" name="btfw-chat-side" value="left"> Chat left, video right
+                    </label>
+                  </div>
+                  <p class="help">Mobile screens switch to a stacked view automatically.</p>
+                </div>
+                <div class="field">
                   <label class="checkbox">
                     <input type="checkbox" id="btfw-pip-toggle"> Picture-in-Picture (experimental)
                   </label>
@@ -201,6 +214,7 @@ BTFW.define("feature:themeSettings", [], async () => {
     const pipOn       = $("#btfw-pip-toggle", m)?.checked;
     const localSubsOn = $("#btfw-localsubs-toggle", m)?.checked;
     const billcastOn  = $("#btfw-billcast-toggle", m)?.checked;
+    const chatSide    = ($$('input[name="btfw-chat-side"]:checked', m)[0]?.value) || "right";
 
     // persist
     set(TS_KEYS.themeMode, themeMode);
@@ -211,6 +225,7 @@ BTFW.define("feature:themeSettings", [], async () => {
     set(TS_KEYS.pipEnabled,  pipOn ? "1":"0");
     set(TS_KEYS.localSubs,   localSubsOn ? "1":"0");
     set(TS_KEYS.billcastEnabled, billcastOn ? "1":"0");
+    set(TS_KEYS.layoutSide, chatSide);
 
     // apply live
     if (bulma?.setTheme) bulma.setTheme(themeMode);
@@ -223,11 +238,13 @@ BTFW.define("feature:themeSettings", [], async () => {
     document.dispatchEvent(new CustomEvent("btfw:chat:gifAutoplayChanged", { detail:{ autoplay: !!gifAutoOn } }));
     document.dispatchEvent(new CustomEvent("btfw:pip:toggled",             { detail:{ enabled : !!pipOn } }));
     document.dispatchEvent(new CustomEvent("btfw:video:localsubs:changed", { detail:{ enabled : !!localSubsOn } }));
+    document.dispatchEvent(new CustomEvent("btfw:layout:chatSideChanged",   { detail:{ side    : chatSide } }));
     document.dispatchEvent(new CustomEvent("btfw:themeSettings:apply",     { detail:{
       values: {
         themeMode, avatarsMode, chatTextPx: parseInt(chatTextPx,10),
         emoteSize, gifAutoplay: !!gifAutoOn, pipEnabled: !!pipOn,
-        localSubs: !!localSubsOn, billcastEnabled: !!billcastOn
+        localSubs: !!localSubsOn, billcastEnabled: !!billcastOn,
+        chatSide
       }
     }}));
   }
@@ -248,6 +265,8 @@ BTFW.define("feature:themeSettings", [], async () => {
     $("#btfw-pip-toggle").checked   = get(TS_KEYS.pipEnabled,  "0") === "1";
     $("#btfw-localsubs-toggle").checked = get(TS_KEYS.localSubs, "1") === "1";
     const bc = $("#btfw-billcast-toggle"); if (bc) bc.checked = get(TS_KEYS.billcastEnabled, "1") === "1";
+    const sideNow = get(TS_KEYS.layoutSide, "right");
+    $$('input[name="btfw-chat-side"]').forEach(i => i.checked = (i.value === sideNow));
 
     m.classList.add("is-active");
     document.dispatchEvent(new CustomEvent("btfw:themeSettings:open"));


### PR DESCRIPTION
## Summary
- update the core grid CSS and layout module to support desktop chat-side preferences and automatically stack the interface into a vertical layout on narrow screens while keeping the chat visible
- add a mobile-friendly overlay for stacked modules with a toggle button in the chat header so secondary panels remain accessible on phones
- extend the theme settings modal with a "Desktop layout" option that lets users store their preferred video/chat orientation

## Testing
- Not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d414bedf448329abdd955f5864af6c