### PR TITLE
Improve vertical layout responsiveness and stack integration

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -12,7 +12,6 @@
   --btfw-chat-min: 320px;
   --btfw-chat-max: 30vw;
   --btfw-split-width: 8px;
-  --btfw-vertical-video: 40vh;
 }
 
 *, *::before, *::after { box-sizing: border-box; }
@@ -74,51 +73,57 @@
   grid-template-areas:
     "video"
     "chat";
-  grid-template-rows: var(--btfw-vertical-video) 1fr;
+  grid-template-rows: auto 1fr;
   grid-row-gap: var(--btfw-gap);
-  min-height: 0;
-  height: calc(100vh - var(--btfw-top) - var(--btfw-gap));
+  min-height: calc(100vh - var(--btfw-top) - var(--btfw-gap));
+  height: auto;
+  align-content: start;
 }
 
 #btfw-grid.btfw-grid--vertical #btfw-vsplit{ display:none; }
 
 #btfw-grid.btfw-grid--vertical #btfw-leftpad{
-  min-height: 220px;
-  max-height: var(--btfw-vertical-video);
-  height: var(--btfw-vertical-video);
+  min-height: 0;
+  height: auto;
+  max-height: none;
   position: relative;
 }
 
 #btfw-grid.btfw-grid--vertical #videowrap{
-  flex: 1 1 auto;
-  min-height: 0;
-  height: 100%;
+  flex: 0 0 auto;
 }
 
-#btfw-grid.btfw-grid--vertical #videowrap iframe{
-  width: 100%;
-  height: 100%;
-  aspect-ratio: unset;
+#btfw-grid.btfw-grid--vertical #videowrap iframe,
+#btfw-grid.btfw-grid--vertical #videowrap video{
+  height: auto;
 }
 
 #btfw-grid.btfw-grid--vertical #btfw-chatcol{
   position: relative;
   top: 0;
-  height: 100%;
+  height: auto;
   min-height: 0;
 }
 
 #btfw-grid.btfw-grid--vertical #chatwrap{
   flex: 1 1 auto;
   min-height: 0;
-  height: 100%;
+  height: auto;
 }
 
 /* ---------- Content Stack under video ---------- */
-#btfw-stack{ 
-  display:block; 
+#btfw-stack{
+  display:block;
   flex: 1; /* Take remaining space in leftpad */
   min-height: 0; /* Allow shrinking */
+}
+#btfw-stack.btfw-stack--in-chat{
+  flex: 0 0 auto;
+  width: 100%;
+  margin-top: var(--btfw-gap);
+}
+#btfw-stack.btfw-stack--in-chat .btfw-stack-list{
+  margin-top: var(--btfw-gap);
 }
 #btfw-stack .btfw-stack-header{
   display:flex; align-items:center; justify-content:space-between;

--- a/css/mobile.css
+++ b/css/mobile.css
@@ -9,7 +9,8 @@
   #btfw-grid.btfw-grid--vertical{
     padding: 0 8px;
     margin-top: calc(var(--btfw-top,48px) + 8px);
-    height: calc(100vh - var(--btfw-top,48px) - 8px);
+    min-height: calc(100vh - var(--btfw-top,48px) - 8px);
+    height: auto;
   }
 
   #btfw-grid.btfw-grid--vertical #btfw-chatcol{

--- a/css/player.css
+++ b/css/player.css
@@ -12,23 +12,44 @@
 /* Support legacy .embed-responsive wrappers if present */
 #videowrap .embed-responsive{
   position: relative;
+  width: 100%;
+  height: auto;
   display: block;
-  height: 0;
   overflow: hidden;
+  aspect-ratio: var(--btfw-video-aspect, 16 / 9);
+  background: #000;
+  border-radius: 12px;
 }
+#videowrap .embed-responsive::before{
+  content: "";
+  display: block;
+  padding-top: 0;
+}
+#videowrap .embed-responsive .embed-responsive-item,
+#videowrap .embed-responsive embed,
 #videowrap .embed-responsive iframe,
+#videowrap .embed-responsive object,
 #videowrap .embed-responsive video{
-  position: absolute; top: 0; left: 0;
-  width: 100%; height: 100%;
+  position: static;
+  top: auto;
+  left: auto;
+  bottom: auto;
+  width: 100%;
+  height: 100%;
+  display: block;
   border: 0;
 }
 
 /* If no wrapper, modern browsers can use aspect-ratio on iframe */
-#videowrap iframe{
+#videowrap iframe,
+#videowrap video{
   width: 100%;
   height: auto;
-  aspect-ratio: 16 / 9;
+  aspect-ratio: var(--btfw-video-aspect, 16 / 9);
   border: 0;
+  display: block;
+  background: #000;
+  border-radius: 12px;
 }
 
 /* Video overlay buttons are styled in overlays.css; ensure interactivity */

--- a/modules/feature-stack.js
+++ b/modules/feature-stack.js
@@ -10,16 +10,22 @@ BTFW.define("feature:stack", ["feature:layout"], async ({}) => {
       priority: 1
     },
     {
-      id: "playlist-group", 
+      id: "playlist-group",
       title: "Playlist",
       selectors: ["#playlistrow", "#playlistwrap", "#queuecontainer", "#queue"],
       priority: 2
     },
     {
-      id: "poll-group",
-      title: "Polls & Voting", 
-      selectors: ["#pollwrap"],
+      id: "channels-group",
+      title: "Featured Channels",
+      selectors: ["#btfw-channels"],
       priority: 3
+    },
+    {
+      id: "poll-group",
+      title: "Polls & Voting",
+      selectors: ["#pollwrap"],
+      priority: 4
     }
   ];
   
@@ -101,12 +107,13 @@ BTFW.define("feature:stack", ["feature:layout"], async ({}) => {
     const plBar = document.getElementById("btfw-plbar");
     const playlistWrap = document.getElementById("playlistwrap");
     const queueContainer = document.getElementById("queuecontainer");
+    const playlistRow = document.getElementById("playlistrow");
 
     // Find any floating controls row (legacy CyTube layout)
     const controlsRows = document.querySelectorAll(".btfw-controls-row");
 
     // Find the main playlist container
-    const mainContainer = playlistWrap || queueContainer;
+    const mainContainer = playlistRow || playlistWrap || queueContainer;
     if (!mainContainer) return;
 
     // Create or enhance the playlist bar
@@ -176,20 +183,29 @@ BTFW.define("feature:stack", ["feature:layout"], async ({}) => {
       }
     };
 
-    // Move rightcontrols buttons into the enhanced bar
-    if (rightControls) {
-      Array.from(rightControls.childNodes).forEach(node => {
+    const moveControls = (root) => {
+      if (!root) return;
+      Array.from(root.childNodes).forEach(node => {
         if (!node || node.nodeType !== 1) return;
         const el = node;
-        // Normalise Bootstrap control groups inside the modern cluster
         el.classList.add("btfw-plbar__control");
         actionsCluster.appendChild(el);
       });
+    };
 
-      actionsCluster.querySelectorAll("button, a.btn, input[type=button], input[type=submit], input[type=reset], select").forEach(styleActionButton);
-
+    // Move rightcontrols buttons into the enhanced bar
+    if (rightControls) {
+      moveControls(rightControls);
       rightControls.remove();
     }
+
+    // Move any remaining legacy controls into the bar
+    if (controlsRow) {
+      moveControls(controlsRow);
+      controlsRow.remove();
+    }
+
+    actionsCluster.querySelectorAll("button, a.btn, input[type=button], input[type=submit], input[type=reset], select").forEach(styleActionButton);
 
     // Move any floating controls rows into the playlist container
     controlsRows.forEach(row => {
@@ -209,10 +225,6 @@ BTFW.define("feature:stack", ["feature:layout"], async ({}) => {
     });
 
     // Hide the legacy controls row if it no longer contains useful content
-    if (controlsRow && !controlsRow.querySelector("button, input, select, .btn, .dropdown")) {
-      controlsRow.style.display = "none";
-    }
-
     // Ensure the bar is at the top of the playlist container
     if (!mainContainer.contains(controlsBar)) {
       mainContainer.insertBefore(controlsBar, mainContainer.firstChild);


### PR DESCRIPTION
## Summary
- update the player wrapper styles so embeds size from width, keep their aspect ratio, and stop inheriting the legacy absolute positioning
- revise the responsive layout to switch to vertical mode around 900–940px, keep the stack under the chat, and coordinate the mobile modules drawer
- fold the playlist controls and channels slider into the stack framework and tweak the mobile grid height for stacked layouts

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d42476208483299b1e1699858bb940