### PR TITLE
Refine palette-driven styling across theme CSS

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -3,17 +3,6 @@
    Layout grid, content stack, and core spacing
    ====================================================================== */
 
-:root {
-  --btfw-top: 48px;                 /* set dynamically by layout module */
-  --btfw-gap: 10px;
-  --btfw-border: rgba(255,255,255,.08);
-  --btfw-card-bg: rgba(20,24,34,.92);
-  --btfw-radius: 12px;
-  --btfw-chat-min: 320px;
-  --btfw-chat-max: 30vw;
-  --btfw-split-width: 8px;
-}
-
 *, *::before, *::after { box-sizing: border-box; }
 
 /* ---------- Main 2-column grid: left content + splitter + right chat ---------- */
@@ -50,7 +39,7 @@
 #btfw-vsplit{
   grid-area: split;
   width: var(--btfw-split-width);
-  background: linear-gradient(90deg, transparent, rgba(255,255,255,.08), transparent);
+  background: linear-gradient(90deg, transparent, color-mix(in srgb, var(--btfw-color-accent) 35%, transparent 65%), transparent);
   border-radius: 4px;
   cursor: col-resize;
   align-self: stretch; /* Ensure splitter takes full height */
@@ -149,22 +138,27 @@
 }
 .btfw-stack-arrows{ display:flex; gap:6px; }
 .btfw-arrow{
-  background:rgba(0,0,0,.25);
+  background: color-mix(in srgb, var(--btfw-color-panel) 30%, transparent 70%);
   border:1px solid var(--btfw-border);
   border-radius:8px;
   padding:2px 8px; line-height:1; cursor:pointer;
+  color: var(--btfw-color-text);
+  transition: background 0.18s ease, color 0.18s ease;
 }
-.btfw-arrow:hover{ background:rgba(255,255,255,.12); }
+.btfw-arrow:hover{
+  background: color-mix(in srgb, var(--btfw-color-accent) 48%, transparent 52%);
+  color: color-mix(in srgb, var(--btfw-color-text) 96%, white 4%);
+}
 .btfw-stack-item__body{ padding:8px; }
 
 /* Grouped items styling */
 .btfw-stack-item.btfw-group-item .btfw-stack-item__header {
-  background: rgba(109, 77, 246, 0.15);
-  border-bottom: 1px solid rgba(109, 77, 246, 0.25);
+  background: color-mix(in srgb, var(--btfw-color-accent) 18%, transparent 82%);
+  border-bottom: 1px solid color-mix(in srgb, var(--btfw-color-accent) 34%, transparent 66%);
 }
 .btfw-stack-item.btfw-group-item .btfw-stack-item__title {
   font-weight: 700;
-  color: #e6edf3;
+  color: var(--btfw-color-text);
 }
 .btfw-group-body {
   display: flex;
@@ -172,9 +166,9 @@
   gap: 8px;
 }
 .btfw-group-body > * {
-  border: 1px solid rgba(255,255,255,.05);
+  border: 1px solid color-mix(in srgb, var(--btfw-border) 60%, transparent 40%);
   border-radius: 8px;
-  background: rgba(255,255,255,.02);
+  background: color-mix(in srgb, var(--btfw-color-surface) 86%, transparent 14%);
   padding: 6px;
 }
 
@@ -196,10 +190,12 @@
   gap: 12px !important;
   padding: 14px 16px !important;
   margin: 12px 0 10px 0 !important;
-  background: linear-gradient(135deg, rgba(109, 77, 246, 0.18), rgba(18, 26, 36, 0.92)) !important;
-  border: 1px solid rgba(109, 77, 246, 0.28) !important;
+  background: linear-gradient(135deg,
+    color-mix(in srgb, var(--btfw-color-accent) 24%, transparent 76%),
+    color-mix(in srgb, var(--btfw-color-panel) 82%, transparent 18%)) !important;
+  border: 1px solid color-mix(in srgb, var(--btfw-color-accent) 32%, transparent 68%) !important;
   border-radius: 14px !important;
-  box-shadow: 0 12px 32px rgba(8, 11, 20, 0.45);
+  box-shadow: 0 12px 32px color-mix(in srgb, var(--btfw-color-bg) 28%, transparent 72%);
 }
 
 .btfw-plbar__layout {
@@ -236,9 +232,9 @@
 
 .btfw-plbar__search .input {
   width: 100%;
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  color: #f3f5ff;
+  background: color-mix(in srgb, var(--btfw-color-surface) 86%, transparent 14%);
+  border: 1px solid color-mix(in srgb, var(--btfw-border) 78%, transparent 22%);
+  color: var(--btfw-color-text);
   border-radius: 10px;
 }
 
@@ -254,11 +250,11 @@
   font-size: 11px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: color-mix(in srgb, var(--btfw-color-accent) 16%, transparent 84%);
+  border: 1px solid color-mix(in srgb, var(--btfw-color-accent) 32%, transparent 68%);
   border-radius: 999px;
   padding: 4px 12px;
-  color: #d7defb;
+  color: color-mix(in srgb, var(--btfw-color-text) 92%, transparent 8%);
   align-self: flex-end;
 }
 
@@ -299,10 +295,10 @@
 .btfw-plbar__actions input[type=button],
 .btfw-plbar__actions input[type=submit],
 .btfw-plbar__actions input[type=reset] {
-  background: rgba(255, 255, 255, 0.07);
-  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: color-mix(in srgb, var(--btfw-color-surface) 82%, transparent 18%);
+  border: 1px solid color-mix(in srgb, var(--btfw-border) 74%, transparent 26%);
   border-radius: 10px;
-  color: #e6edf8 !important;
+  color: var(--btfw-color-text) !important;
   padding: 6px 12px;
   font-size: 12px;
   font-weight: 600;
@@ -311,10 +307,10 @@
 }
 
 .btfw-plbar__actions select {
-  background: rgba(12, 16, 26, 0.85);
-  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: color-mix(in srgb, var(--btfw-color-panel) 88%, transparent 12%);
+  border: 1px solid color-mix(in srgb, var(--btfw-border) 78%, transparent 22%);
   border-radius: 10px;
-  color: #f5f7ff;
+  color: var(--btfw-color-text);
   padding: 6px 10px;
   font-size: 12px;
 }
@@ -326,8 +322,8 @@
 .btfw-plbar__actions input[type=submit]:hover,
 .btfw-plbar__actions input[type=reset]:hover,
 .btfw-plbar__actions select:hover {
-  background: rgba(109, 77, 246, 0.22) !important;
-  border-color: rgba(109, 77, 246, 0.5) !important;
+  background: color-mix(in srgb, var(--btfw-color-accent) 36%, transparent 64%) !important;
+  border-color: color-mix(in srgb, var(--btfw-color-accent) 52%, transparent 48%) !important;
 }
 
 .btfw-plbar__actions button:active,
@@ -393,7 +389,7 @@
   min-width: 48px;
   text-align: right;
   font-variant-numeric: tabular-nums;
-  color: rgba(240, 244, 255, 0.85);
+  color: color-mix(in srgb, var(--btfw-color-text) 88%, transparent 12%);
 }
 
 /* Ensure videowrap doesn't collapse during load */

--- a/css/chat.css
+++ b/css/chat.css
@@ -3,12 +3,6 @@
    Chat column structure, message area, avatars, and controls row
    ====================================================================== */
 
-:root{
-  --btfw-top: 48px;
-  --btfw-border: rgba(255,255,255,.08);
-  --btfw-radius: 12px;
-}
-
 #chatwrap{
   display:flex;
   flex-direction: column;
@@ -93,7 +87,7 @@
   align-items:center;
   padding:6px;
   border-top:1px solid var(--btfw-border);
-  background: rgba(20,24,34,.92);
+  background: color-mix(in srgb, var(--btfw-color-panel) 84%, transparent 16%);
   border-radius: 10px;
   margin-top:6px;
   flex-shrink: 0; /* Don't shrink the controls */
@@ -115,7 +109,7 @@
   margin-right: 8px;
   vertical-align: middle;
   object-fit: cover;
-  box-shadow: 0 1px 4px rgba(0,0,0,.35);
+  box-shadow: 0 1px 4px color-mix(in srgb, var(--btfw-color-bg) 40%, transparent 60%);
 }
 #messagebuffer .btfw-chat-avatar + .username{ vertical-align: middle; }
 
@@ -143,17 +137,17 @@
 #btfw-chattools{
   display:flex; align-items:center; justify-content:space-between;
   gap:8px; padding:6px; margin-bottom:6px;
-  border:1px solid rgba(255,255,255,.08);
-  border-radius:12px; background: rgba(20,24,34,.92);
+  border:1px solid var(--btfw-border);
+  border-radius:12px; background: color-mix(in srgb, var(--btfw-color-panel) 84%, transparent 16%);
 }
 #btfw-chattools .btfw-ct{ border-radius:10px; }
 #btfw-ct-swatch{
   position: sticky; margin-top:6px; right:6px;
   display:grid; grid-template-columns: repeat(8, 22px); gap:6px;
   padding:8px; border-radius:10px;
-  background: rgba(10,14,20,.98);
-  border:1px solid rgba(255,255,255,.08);
-  box-shadow: 0 10px 26px rgba(0,0,0,.4);
+  background: color-mix(in srgb, var(--btfw-color-panel) 90%, transparent 10%);
+  border:1px solid var(--btfw-border);
+  box-shadow: 0 10px 26px color-mix(in srgb, var(--btfw-color-bg) 35%, transparent 65%);
   z-index: 4700;
 }
 #btfw-ct-swatch.is-hidden{ display:none; }
@@ -167,10 +161,10 @@
 .btfw-ct-pop{
   position: absolute;
   left: 8px; right: 8px; bottom: 86px; /* JS adjusts bottom at runtime */
-  background: rgba(20,24,34,.98);
-  border: 1px solid rgba(255,255,255,.08);
+  background: color-mix(in srgb, var(--btfw-color-panel) 92%, transparent 8%);
+  border: 1px solid var(--btfw-border);
   border-radius: 12px;
-  box-shadow: 0 16px 40px rgba(0,0,0,.5);
+  box-shadow: 0 16px 40px color-mix(in srgb, var(--btfw-color-bg) 38%, transparent 62%);
   padding: 10px;
   z-index: 4700;
 }
@@ -186,12 +180,12 @@
   gap: 4px;
   padding: 10px 8px;
   border-radius: 10px;
-  background: rgba(0,0,0,.25);
-  border: 1px solid rgba(255,255,255,.08);
+  background: color-mix(in srgb, var(--btfw-color-panel) 78%, transparent 22%);
+  border: 1px solid var(--btfw-border);
   cursor: pointer;
   user-select: none;
 }
-.btfw-ct-item:hover{ background: rgba(255,255,255,.12); }
+.btfw-ct-item:hover{ background: color-mix(in srgb, var(--btfw-color-accent) 34%, transparent 66%); }
 .btfw-ct-item > span { font-size: 12px; opacity: .9; }
 
 .btfw-ct-swatch{
@@ -199,8 +193,8 @@
   display:grid; grid-template-columns: repeat(10, 22px); gap: 6px;
   padding: 8px;
   border-radius: 10px;
-  background: rgba(10,14,20,.98);
-  border: 1px solid rgba(255,255,255,.08);
+  background: color-mix(in srgb, var(--btfw-color-panel) 90%, transparent 10%);
+  border: 1px solid var(--btfw-border);
 }
 .btfw-ct-swatch.is-hidden{ display:none; }
 .btfw-ct-swatchbtn{
@@ -222,26 +216,34 @@
 #btfw-ct-modal.is-active{ display: block; }
 #btfw-ct-modal .btfw-ct-backdrop{
   position: absolute; inset: 0;
-  background: rgba(0,0,0,.45);
+  background: color-mix(in srgb, var(--btfw-color-bg) 40%, black 60%);
   border-radius: 12px; /* matches chat column rounding if any */
 }
 #btfw-ct-modal .btfw-ct-card{
-  position: absolute; 
-  background: linear-gradient(180deg, #1b1624 0%, #171b24 100%);
-  border: 1px solid rgba(255,255,255,.08);
+  position: absolute;
+  background: linear-gradient(180deg,
+    color-mix(in srgb, var(--btfw-color-panel) 90%, transparent 10%),
+    color-mix(in srgb, var(--btfw-color-surface) 88%, transparent 12%));
+  border: 1px solid var(--btfw-border);
   border-radius: 14px;
-  box-shadow: 0 18px 44px rgba(0,0,0,.55);
-  color: #eaeaf0;
+  box-shadow: 0 18px 44px color-mix(in srgb, var(--btfw-color-bg) 34%, transparent 66%);
+  color: var(--btfw-color-text);
   overflow: hidden;
 }
 #btfw-ct-modal .btfw-ct-cardhead{
   display:flex; align-items:center; justify-content:space-between;
   padding: 10px 12px;
-  background: linear-gradient(90deg,#702b8f 0%, #a03dc0 100%);
-  color: #fff; font-weight: 600; letter-spacing: .2px;
+  background: linear-gradient(90deg,
+    color-mix(in srgb, var(--btfw-color-accent) 96%, transparent 4%),
+    color-mix(in srgb, var(--btfw-color-accent) 80%, white 20%));
+  color: var(--btfw-color-text); font-weight: 600; letter-spacing: .2px;
 }
 #btfw-ct-modal .btfw-ct-close{
-  background: transparent; border: 0; color: #fff; font-size: 18px; cursor: pointer;
+  background: transparent;
+  border: 0;
+  color: var(--btfw-color-on-accent);
+  font-size: 18px;
+  cursor: pointer;
 }
 #btfw-ct-modal .btfw-ct-body{ padding: 10px 12px 12px; }
 
@@ -253,10 +255,10 @@
   display:flex; flex-direction:column; align-items:center; justify-content:center;
   gap: 3px; padding:10px 8px; cursor:pointer;
   border-radius: 10px;
-  background: rgba(255,255,255,.06);
-  border: 1px solid rgba(255,255,255,.1);
+  background: color-mix(in srgb, var(--btfw-color-surface) 82%, transparent 18%);
+  border: 1px solid color-mix(in srgb, var(--btfw-border) 72%, transparent 28%);
 }
-#btfw-ct-modal .btfw-ct-item:hover{ background: rgba(255,255,255,.12); }
+#btfw-ct-modal .btfw-ct-item:hover{ background: color-mix(in srgb, var(--btfw-color-accent) 32%, transparent 68%); }
 #btfw-ct-modal .btfw-ct-item > span{ font-size: 12px; opacity:.9; }
 
 #btfw-ct-modal .btfw-ct-section{ margin-top: 6px; }
@@ -276,27 +278,28 @@
   display:flex; align-items:center; gap:8px; margin-top:8px;
 }
 #btfw-ct-modal .btfw-ct-hex{
-  width:110px; background:#0f1218; color:#e9e9ee; border:1px solid rgba(255,255,255,.1);
+  width:110px; background:color-mix(in srgb, var(--btfw-color-panel) 86%, transparent 14%); color:var(--btfw-color-text); border:1px solid color-mix(in srgb, var(--btfw-border) 76%, transparent 24%);
   border-radius:8px; padding:6px 8px;
 }
 
 /* Subtle polish for chat input row to echo style reference */
 .btfw-controls-row{
-  background: #121821;
-  border: 1px solid rgba(255,255,255,.08);
-  box-shadow: 0 8px 24px rgba(0,0,0,.35) inset;
+  background: color-mix(in srgb, var(--btfw-color-panel) 82%, transparent 18%);
+  border: 1px solid var(--btfw-border);
+  box-shadow: 0 8px 24px color-mix(in srgb, var(--btfw-color-bg) 32%, transparent 68%) inset;
   border-radius: 12px;
 }
 #chatline{
-  background: #0e131b; color: #e8eaf0;
-  border: 1px solid rgba(255,255,255,.08);
+  background: color-mix(in srgb, var(--btfw-color-panel) 78%, transparent 22%);
+  color: var(--btfw-color-text);
+  border: 1px solid var(--btfw-border);
   border-radius: 10px;
   padding: 8px 10px;
 }
 .btfw-chat-actions .button.btfw-chatbtn{
   border-radius: 999px;
-  background: radial-gradient(120% 120% at 30% 30%, rgba(255,255,255,.12), rgba(0,0,0,.15));
-  border: 1px solid rgba(255,255,255,.08);
+  background: radial-gradient(120% 120% at 30% 30%, color-mix(in srgb, var(--btfw-color-accent) 26%, transparent 74%), color-mix(in srgb, var(--btfw-color-panel) 78%, transparent 22%));
+  border: 1px solid color-mix(in srgb, var(--btfw-border) 72%, transparent 28%);
 }
 .btfw-chat-actions .button.btfw-chatbtn:hover{ filter: brightness(1.08); }
 
@@ -323,9 +326,9 @@
 
 /* Fallback quick control styling (if Theme Settings modal is absent) */
 .btfw-avatars-dd .btfw-avatars-select{
-  background: rgba(0,0,0,.25);
-  border: 1px solid rgba(255,255,255,.08);
-  color: #e9e9ee;
+  background: color-mix(in srgb, var(--btfw-color-panel) 80%, transparent 20%);
+  border: 1px solid var(--btfw-border);
+  color: var(--btfw-color-text);
   border-radius: 8px;
   padding: 4px 8px;
 }
@@ -348,20 +351,22 @@
   gap: 6px;
   padding: 6px 14px;
   border-radius: 999px;
-  background: linear-gradient(135deg, rgba(33, 43, 66, 0.95), rgba(25, 31, 49, 0.95));
-  border: 1px solid rgba(109, 77, 246, 0.4);
-  color: #f3f6ff;
+  background: linear-gradient(135deg,
+    color-mix(in srgb, var(--btfw-color-panel) 88%, transparent 12%),
+    color-mix(in srgb, var(--btfw-color-accent) 38%, var(--btfw-color-panel) 62%));
+  border: 1px solid color-mix(in srgb, var(--btfw-color-accent) 42%, transparent 58%);
+  color: var(--btfw-color-text);
   font-size: 13px;
   font-weight: 600;
   letter-spacing: 0.01em;
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
+  box-shadow: 0 12px 28px color-mix(in srgb, var(--btfw-color-bg) 32%, transparent 68%);
   cursor: pointer;
   transition: transform 0.16s ease, box-shadow 0.16s ease;
 }
 
 #chatwrap .btfw-newmessages-slot #newmessages-indicator:hover{
   transform: translateY(-2px);
-  box-shadow: 0 16px 32px rgba(109, 77, 246, 0.35);
+  box-shadow: 0 16px 32px color-mix(in srgb, var(--btfw-color-accent) 35%, transparent 65%);
 }
 
 #chatwrap .btfw-newmessages-slot #newmessages-indicator .glyphicon{
@@ -400,7 +405,7 @@ img.twemoji { width: 1em; height: 1em; vertical-align: -0.15em; }
 #messagebuffer img.twemoji { width: 1.1em; height: 1.1em; }
 
 #userlist, #messagebuffer, #chatheader, #videowrap-header {
-    border: 0px solid #aaaaaa!important;
+    border: 0 solid transparent!important;
         scroll-behavior: smooth;
     overflow-x: hidden;
 }
@@ -419,8 +424,12 @@ img.twemoji { width: 1em; height: 1em; vertical-align: -0.15em; }
 }
 
 #userlist::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.22);
+  background: var(--btfw-scrollbar-thumb);
   border-radius: 999px;
+}
+
+#userlist::-webkit-scrollbar-thumb:hover {
+  background: var(--btfw-scrollbar-thumb-hover);
 }
 
 #userlist::-webkit-scrollbar-track {
@@ -477,11 +486,18 @@ body.btfw-ts-hide #messagebuffer .timestamp { display:none !important; }
 /* Muted user indicator in userlist */
 #userlist li.btfw-muted { opacity: .55; }
 #userlist .btfw-mute-chip {
-  margin-left: 6px; padding: 2px 6px; font-size: 11px;
-  border: 0; border-radius: 10px; cursor: pointer;
-  background: rgba(255,255,255,.10); color: #ddd;
+  margin-left: 6px;
+  padding: 2px 6px;
+  font-size: 11px;
+  border: 0;
+  border-radius: 10px;
+  cursor: pointer;
+  background: var(--btfw-chip-bg);
+  color: var(--btfw-chip-text);
 }
-#userlist .btfw-mute-chip:hover { background: rgba(255,255,255,.18); }
+#userlist .btfw-mute-chip:hover {
+  background: var(--btfw-chip-bg-hover);
+}
 
 /* Chat bottom bar split: actions (left) + usercount (right) */
 .btfw-chat-bottombar{

--- a/css/mobile.css
+++ b/css/mobile.css
@@ -35,7 +35,7 @@
   content: "";
   position: absolute;
   inset: 0;
-  background: rgba(7,10,16,0.72);
+  background: color-mix(in srgb, var(--btfw-color-bg) 80%, transparent 20%);
   backdrop-filter: blur(10px);
 }
 
@@ -47,10 +47,10 @@
   flex-direction: column;
   gap: 12px;
   padding: 16px;
-  border-radius: 16px;
-  border: 1px solid rgba(255,255,255,0.1);
-  background: rgba(20,24,34,0.94);
-  box-shadow: 0 22px 48px rgba(4,6,12,0.6);
+  border-radius: calc(var(--btfw-radius) + 4px);
+  border: 1px solid var(--btfw-border);
+  background: color-mix(in srgb, var(--btfw-overlay-bg) 94%, transparent 6%);
+  box-shadow: var(--btfw-overlay-shadow);
   overflow: hidden;
 }
 
@@ -68,8 +68,8 @@
 
 #btfw-mobile-stack .btfw-mobile-stack__close{
   border: 0;
-  background: rgba(255,255,255,0.08);
-  color: #fff;
+  background: color-mix(in srgb, var(--btfw-color-panel) 84%, transparent 16%);
+  color: var(--btfw-color-text);
   border-radius: 10px;
   padding: 6px 10px;
   font-size: 0.95rem;
@@ -77,7 +77,7 @@
 }
 
 #btfw-mobile-stack .btfw-mobile-stack__close:hover{
-  background: rgba(255,255,255,0.16);
+  background: color-mix(in srgb, var(--btfw-color-accent) 34%, transparent 66%);
 }
 
 #btfw-mobile-stack .btfw-mobile-stack__body{

--- a/css/navbar.css
+++ b/css/navbar.css
@@ -3,8 +3,6 @@
    Keep content clear of fixed navbar; theme button styling
    ====================================================================== */
 
-:root{ --btfw-top: 48px; }
-
 /* Z-index is enforced in overlays.css; here we ensure spacing below it */
 #btfw-grid{
   margin-top: calc(var(--btfw-top));
@@ -13,12 +11,12 @@
 /* Theme button in navbar */
 #btfw-theme-btn-nav.button{
   border-radius: 10px;
-  border: 1px solid rgba(255,255,255,.08);
-  background: rgba(0,0,0,.25);
+  border: 1px solid color-mix(in srgb, var(--btfw-color-accent) 22%, transparent 78%);
+  background: color-mix(in srgb, var(--btfw-color-panel) 82%, transparent 18%);
   padding: 6px 10px;
 }
 #btfw-theme-btn-nav.button:hover{
-  background: rgba(255,255,255,.12);
+  background: color-mix(in srgb, var(--btfw-color-accent) 36%, transparent 64%);
 }
 
 .btfw-topbar {
@@ -28,9 +26,9 @@
   width: 100%;
   height: 56px;
   padding: 6px 12px;
-  background: #0f131a; /* dark slate */
-  border-bottom: 1px solid rgba(255,255,255,.08);
-  position: sticky; 
+  background: color-mix(in srgb, var(--btfw-color-panel) 88%, transparent 12%);
+  border-bottom: 1px solid var(--btfw-border);
+  position: sticky;
   top: 0;
   z-index: 3000;
 }
@@ -44,24 +42,24 @@
 
 /* Links look tidy */
 .btfw-topbar > li > a {
-  color: #dfe6f3 !important;
+  color: color-mix(in srgb, var(--btfw-color-text) 92%, transparent 8%) !important;
   padding: 8px 10px;
   border-radius: 8px;
 }
 .btfw-topbar > li > a:hover {
-  background: rgba(255,255,255,.06);
-  color: #fff !important;
+  background: color-mix(in srgb, var(--btfw-color-accent) 28%, transparent 72%);
+  color: var(--btfw-color-text) !important;
 }
 
 /* Theme button pill (purple gradient) */
 .btfw-topbar > li > a#btfw-theme-btn-nav {
-  background: linear-gradient(90deg, #6d4df6 0%, #9a63ff 100%);
-  color: #fff !important;
+  background: linear-gradient(90deg, color-mix(in srgb, var(--btfw-color-accent) 100%, transparent 0%), color-mix(in srgb, var(--btfw-color-accent) 80%, white 20%));
+  color: var(--btfw-color-text) !important;
   border: 0;
   font-weight: 600;
   padding: 8px 14px;
   border-radius: 999px;
-  box-shadow: 0 6px 16px rgba(109,77,246,.25);
+  box-shadow: 0 6px 16px color-mix(in srgb, var(--btfw-color-accent) 28%, transparent 72%);
 }
 .btfw-topbar > li > a#btfw-theme-btn-nav:hover {
   filter: brightness(1.06);
@@ -74,8 +72,8 @@
   border-radius: 50%;
   object-fit: cover;
   display: block;
-  border: 2px solid rgba(255,255,255,.16);
-  box-shadow: 0 4px 10px rgba(0,0,0,.25);
+  border: 2px solid color-mix(in srgb, var(--btfw-color-accent) 30%, transparent 70%);
+  box-shadow: 0 4px 10px color-mix(in srgb, var(--btfw-color-bg) 35%, transparent 65%);
 }
 
 /* Space around avatar link */
@@ -85,11 +83,11 @@
   border-radius: 999px;
 }
 .btfw-topbar li.btfw-avatar-li .btfw-avatar-link:hover {
-  background: rgba(255,255,255,.06);
+  background: color-mix(in srgb, var(--btfw-color-accent) 24%, transparent 76%);
 }
 
 /* Optional: hide the old Bootstrap divider lines inside dropdowns when using dark bar */
-.btfw-topbar .dropdown-menu .divider { background-color: rgba(255,255,255,.08); }
+.btfw-topbar .dropdown-menu .divider { background-color: color-mix(in srgb, var(--btfw-color-accent) 26%, transparent 74%); }
 /* Navbar avatar */
 .btfw-nav-avatar-item { display:inline-block; margin-left:12px; }
 .btfw-nav-avatar-link { display:inline-flex; align-items:center; }
@@ -97,8 +95,8 @@
   width: 28px; height: 28px;
   border-radius: 50%;
   object-fit: cover;
-  border: 1px solid rgba(255,255,255,.25);
-  box-shadow: 0 0 0 2px rgba(0,0,0,.15);
+  border: 1px solid color-mix(in srgb, var(--btfw-color-accent) 30%, transparent 70%);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--btfw-color-bg) 40%, transparent 60%);
 }
 @media (min-width: 768px) {
     .navbar-nav {

--- a/css/overlays.css
+++ b/css/overlays.css
@@ -46,11 +46,11 @@
   z-index: 6002 !important;
   width: min(300px, calc(100vw - 24px)) !important;
   max-height: 55vh !important;
-  background: rgba(20, 24, 34, 0.97);
-  color: #e9e9ee;
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 14px 40px rgba(0, 0, 0, 0.5);
+  background: color-mix(in srgb, var(--btfw-overlay-bg) 96%, transparent 4%);
+  color: var(--btfw-color-text);
+  border-radius: var(--btfw-radius);
+  border: 1px solid var(--btfw-overlay-border);
+  box-shadow: var(--btfw-overlay-shadow);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -128,14 +128,14 @@
 
 #videowrap .btfw-video-overlay .btfw-vo-btn {
   border-radius: 10px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid var(--btfw-overlay-border);
+  background: color-mix(in srgb, var(--btfw-color-bg) 78%, transparent 22%);
   backdrop-filter: saturate(130%) blur(4px);
   padding: 6px 10px;
   line-height: 1;
 }
 #videowrap .btfw-video-overlay .btfw-vo-btn:hover {
-  background: rgba(255, 255, 255, 0.12);
+  background: color-mix(in srgb, var(--btfw-color-accent) 32%, transparent 68%);
 }
 
 /* ======================================================================
@@ -150,9 +150,9 @@
   justify-content: center;
 }
 #videowrap.btfw-pip {
-  border-radius: 12px;
+  border-radius: var(--btfw-radius);
   overflow: hidden;
-  box-shadow: 0 10px 30px rgba(0,0,0,.5);
+  box-shadow: 0 10px 30px color-mix(in srgb, var(--btfw-color-bg) 54%, transparent 46%);
 }
 
 /* ======================================================================
@@ -162,27 +162,29 @@
 
 .btfw-chat-topbar,
 .btfw-chat-bottombar {
-  background: linear-gradient(180deg, #1b2130, #212a3f);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 12px;
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
+  background: linear-gradient(180deg,
+    color-mix(in srgb, var(--btfw-overlay-bg) 88%, transparent 12%),
+    color-mix(in srgb, var(--btfw-overlay-elevated) 88%, transparent 12%));
+  border: 1px solid var(--btfw-border);
+  border-radius: var(--btfw-radius);
+  box-shadow: 0 12px 28px color-mix(in srgb, var(--btfw-color-bg) 48%, transparent 52%);
 }
 
 .btfw-chat-actions .button.btfw-chatbtn {
   border-radius: 10px;
-  border: 1px solid rgba(255,255,255,.08);
-  background: rgba(0,0,0,.25);
+  border: 1px solid var(--btfw-border);
+  background: color-mix(in srgb, var(--btfw-color-bg) 74%, transparent 26%);
 }
 .btfw-chat-actions .button.btfw-chatbtn:hover {
-  background: rgba(255,255,255,.12);
+  background: color-mix(in srgb, var(--btfw-color-accent) 32%, transparent 68%);
 }
 
 /* Keep the chat controls row visible at the bottom of chat column */
 .btfw-controls-row {
   position: sticky;
   bottom: 0;
-  background: #141a26;
-  border-top: 1px solid rgba(255,255,255,.08);
+  background: color-mix(in srgb, var(--btfw-overlay-bg) 90%, transparent 10%);
+  border-top: 1px solid var(--btfw-border);
   z-index: 10;
 }
 /* --- BTFW Emotes Popover (mini) --- */
@@ -196,10 +198,10 @@
   max-width: calc(100% - 16px);
   display: flex;
   flex-direction: column;
-  background: rgba(18, 22, 29, 0.92);
-  border: 1px solid rgba(255,255,255,.07);
-  border-radius: 12px;
-  box-shadow: 0 8px 26px rgba(0,0,0,.45);
+  background: color-mix(in srgb, var(--btfw-overlay-bg) 94%, transparent 6%);
+  border: 1px solid var(--btfw-overlay-border);
+  border-radius: var(--btfw-radius);
+  box-shadow: var(--btfw-overlay-shadow);
   backdrop-filter: saturate(120%) blur(8px);
   z-index: 6000;
   overflow: hidden;
@@ -209,22 +211,22 @@
 #btfw-emotes-pop .btfw-emotes-head {
   display: flex; align-items: center; gap: 8px;
   padding: 8px 10px;
-  border-bottom: 1px solid rgba(255,255,255,.08);
+  border-bottom: 1px solid var(--btfw-border);
 }
 
 #btfw-emotes-pop .btfw-emotes-tabs { display: inline-flex; gap: 4px; }
 #btfw-emotes-pop .btfw-tab {
-  background: rgba(255,255,255,.05);
-  color: #cfe2ff;
-  border: 1px solid rgba(255,255,255,.08);
+  background: color-mix(in srgb, var(--btfw-color-panel) 78%, transparent 22%);
+  color: var(--btfw-color-text-soft);
+  border: 1px solid var(--btfw-border);
   border-radius: 8px;
   padding: 6px 10px;
   font-size: 12px; line-height: 1; cursor: pointer;
 }
 #btfw-emotes-pop .btfw-tab.is-active {
-  background: rgba(109,77,246,.25);
-  border-color: rgba(109,77,246,.55);
-  color: #fff;
+  background: color-mix(in srgb, var(--btfw-color-accent) 42%, transparent 58%);
+  border-color: color-mix(in srgb, var(--btfw-color-accent) 64%, transparent 36%);
+  color: var(--btfw-color-on-accent);
 }
 
 #btfw-emotes-pop .btfw-emotes-search {
@@ -232,25 +234,27 @@
   display: inline-flex; align-items: center; gap: 6px;
 }
 #btfw-emotes-pop #btfw-emotes-search {
-  background: rgba(255,255,255,.06);
-  border: 1px solid rgba(255,255,255,.12);
-  color: #e7ecf5;
+  background: color-mix(in srgb, var(--btfw-color-panel) 86%, transparent 14%);
+  border: 1px solid var(--btfw-border);
+  color: var(--btfw-color-text);
   border-radius: 8px;
   font-size: 12px; padding: 6px 8px; width: 180px;
 }
 #btfw-emotes-pop #btfw-emotes-clear {
-  background: rgba(255,255,255,.06);
-  border: 1px solid rgba(255,255,255,.12);
-  color: #cfe2ff;
+  background: color-mix(in srgb, var(--btfw-color-panel) 84%, transparent 16%);
+  border: 1px solid var(--btfw-border);
+  color: var(--btfw-color-text-soft);
   border-radius: 8px;
   width: 28px; height: 28px; line-height: 1; cursor: pointer;
 }
 #btfw-emotes-pop .btfw-emotes-close {
   margin-left: 8px;
   width: 28px; height: 28px;
-  border-radius: 8px; border: 1px solid rgba(255,255,255,.12);
-  background: rgba(255,255,255,.06);
-  color: #cfe2ff; cursor: pointer;
+  border-radius: 8px;
+  border: 1px solid var(--btfw-border);
+  background: color-mix(in srgb, var(--btfw-color-panel) 82%, transparent 18%);
+  color: var(--btfw-color-text-soft);
+  cursor: pointer;
 }
 
 /* Fixed grid: constant tile size & no hover-jump */
@@ -268,16 +272,16 @@
 
 #btfw-emotes-grid .btfw-emote-tile {
   display:flex; align-items:center; justify-content:center;
-  border: 1px solid rgba(255,255,255,.08);
+  border: 1px solid var(--btfw-border);
   border-radius: 10px; cursor: pointer;
-  background: rgba(255,255,255,.04);
+  background: color-mix(in srgb, var(--btfw-color-panel) 80%, transparent 20%);
   /* keep size constant: no transform on hover */
   transition: background .12s ease, border-color .12s ease;
 }
 #btfw-emotes-grid .btfw-emote-tile:hover {
-  background: rgba(255,255,255,.08);
+  background: color-mix(in srgb, var(--btfw-color-accent) 28%, transparent 72%);
 }
-#btfw-emotes-grid .btfw-emote-tile.is-active { outline: 2px solid #6d4df6; }
+#btfw-emotes-grid .btfw-emote-tile.is-active { outline: 2px solid color-mix(in srgb, var(--btfw-color-accent) 68%, transparent 32%); }
 .btfw-emote-img { max-width: 42px; max-height: 42px; }
 .btfw-emoji { font-size: 26px; line-height: 1; }
 
@@ -286,14 +290,14 @@
 }
 
 #btfw-emotes-grid .btfw-emote-tile--emoji {
-  background: rgba(255,255,255,0.035);
+  background: color-mix(in srgb, var(--btfw-color-panel) 76%, transparent 24%);
 }
 
 #btfw-emotes-grid .btfw-emote-tile--emoji .btfw-emoji {
   font-family: "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", "Twemoji Mozilla", "Noto Emoji", sans-serif;
   font-size: 30px;
   transition: transform 0.14s ease;
-  filter: drop-shadow(0 2px 4px rgba(0,0,0,0.35));
+  filter: drop-shadow(0 2px 4px color-mix(in srgb, var(--btfw-color-bg) 48%, transparent 52%));
 }
 
 #btfw-emotes-grid .btfw-emote-tile--emoji:hover .btfw-emoji,
@@ -318,40 +322,28 @@
 /* Scope to Bulma modals; works for Theme Settings, GIFs, etc.            */
 /* Reads CSS variables if you have tokens.css, otherwise uses fallbacks.   */
 
-:root {
-  --btfw-surface-0: rgba(12, 16, 22, 0.92);
-  --btfw-surface-1: #0f131a;
-  --btfw-surface-2: #0c1118;
-  --btfw-border: rgba(255,255,255,.08);
-  --btfw-text-1: #e8ecf3;
-  --btfw-text-2: #a9b2c3;
-  --btfw-accent: #6d4df6;
-  --btfw-accent-2: #8b5cf6;
-  --btfw-shadow-xxl: 0 18px 48px rgba(0,0,0,.55), 0 2px 8px rgba(0,0,0,.35);
-}
-
 /* Backdrop */
 .modal.is-active .modal-background {
   background:
-    radial-gradient(1200px 700px at 20% -10%, rgba(109,77,246,.18), transparent 55%),
-    radial-gradient(1000px 800px at 120% 120%, rgba(24,182,255,.12), transparent 50%),
-    rgba(3, 6, 10, .82);
+    radial-gradient(1200px 700px at 20% -10%, color-mix(in srgb, var(--btfw-color-accent) 22%, transparent 78%), transparent 55%),
+    radial-gradient(1000px 800px at 120% 120%, color-mix(in srgb, var(--btfw-color-accent) 14%, white 4%, transparent 82%), transparent 50%),
+    color-mix(in srgb, var(--btfw-color-bg) 88%, transparent 12%);
 }
 
 /* Card shell */
 .modal-card {
-  background: var(--btfw-surface-1);
-  color: var(--btfw-text-1);
-  border: 1px solid var(--btfw-border);
-  border-radius: 16px;
+  background: var(--btfw-overlay-elevated);
+  color: var(--btfw-color-text);
+  border: 1px solid var(--btfw-overlay-border);
+  border-radius: calc(var(--btfw-radius) + 4px);
   overflow: hidden;
-  box-shadow: var(--btfw-shadow-xxl);
+  box-shadow: var(--btfw-overlay-shadow);
 }
 
 /* Header / footer */
 .modal-card-head,
 .modal-card-foot {
-  background: var(--btfw-surface-2);
+  background: color-mix(in srgb, var(--btfw-overlay-bg) 96%, transparent 4%);
   border-color: var(--btfw-border);
 }
 
@@ -361,7 +353,7 @@
 }
 
 .modal-card-title {
-  color: var(--btfw-text-1);
+  color: var(--btfw-color-text);
   font-weight: 700;
   letter-spacing: .2px;
 }
@@ -375,59 +367,61 @@
 
 /* Body */
 .modal-card-body {
-  background: var(--btfw-surface-1)!important;
-  color: var(--btfw-text-1)!important;
+  background: var(--btfw-overlay-elevated)!important;
+  color: var(--btfw-color-text)!important;
 }
 
 /* Tabs (boxy) */
 .modal .tabs.is-boxed a {
   border-color: var(--btfw-border) !important;
-  background: rgba(255,255,255,.03);
-  color: var(--btfw-text-2);
+  background: color-mix(in srgb, var(--btfw-color-panel) 80%, transparent 20%);
+  color: var(--btfw-color-text-muted);
 }
 .modal .tabs.is-boxed li.is-active a {
-  background: rgba(109,77,246,.22) !important;
-  color: #fff !important;
-  border-color: rgba(109,77,246,.55) !important;
+  background: color-mix(in srgb, var(--btfw-color-accent) 36%, transparent 64%) !important;
+  color: var(--btfw-color-on-accent) !important;
+  border-color: color-mix(in srgb, var(--btfw-color-accent) 56%, transparent 44%) !important;
 }
 
 /* Inputs */
 .modal .input,
 .modal .textarea,
 .modal .select select {
-  background: rgba(255,255,255,.06);
+  background: color-mix(in srgb, var(--btfw-color-panel) 86%, transparent 14%);
   border: 1px solid var(--btfw-border);
-  color: var(--btfw-text-1);
+  color: var(--btfw-color-text);
   box-shadow: none;
 }
 .modal .input::placeholder,
-.modal .textarea::placeholder { color: rgba(233,240,255,.5); }
+.modal .textarea::placeholder { color: color-mix(in srgb, var(--btfw-color-text) 52%, transparent 48%); }
 .modal .input:focus,
 .modal .textarea:focus,
 .modal .select select:focus {
-  border-color: var(--btfw-accent);
-  box-shadow: 0 0 0 2px rgba(109,77,246,.35);
+  border-color: var(--btfw-color-accent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--btfw-color-accent) 40%, transparent 60%);
 }
 
 /* Checkboxes / radios (modern browsers) */
 .modal .checkbox input,
-.modal .radio input { accent-color: var(--btfw-accent); }
+.modal .radio input { accent-color: var(--btfw-color-accent); }
 
 /* Buttons */
 .modal .button {
   border-radius: 10px;
   border: 1px solid var(--btfw-border);
-  background: rgba(255,255,255,.05);
-  color: var(--btfw-text-1);
+  background: color-mix(in srgb, var(--btfw-color-panel) 80%, transparent 20%);
+  color: var(--btfw-color-text);
 }
-.modal .button:hover { background: rgba(255,255,255,.08); }
+.modal .button:hover { background: color-mix(in srgb, var(--btfw-color-accent) 26%, transparent 74%); }
 
 .modal .button.is-link,
 .modal .button.is-primary {
-  background: linear-gradient(135deg, var(--btfw-accent), var(--btfw-accent-2));
+  background: linear-gradient(135deg,
+    color-mix(in srgb, var(--btfw-color-accent) 92%, transparent 8%),
+    color-mix(in srgb, var(--btfw-color-accent) 74%, white 26%));
   border: none;
-  color: #fff;
-  box-shadow: 0 6px 20px rgba(109,77,246,.35);
+  color: var(--btfw-color-on-accent);
+  box-shadow: 0 6px 20px color-mix(in srgb, var(--btfw-color-accent) 32%, transparent 68%);
 }
 .modal .button.is-link:hover,
 .modal .button.is-primary:hover {
@@ -458,9 +452,9 @@
 
 #btfw-gif-notice {
   margin: 6px 0 10px;
-  color: #ffc;
-  background: rgba(255,255,0,.08);
-  border: 1px solid rgba(255,255,0,.25);
+  color: color-mix(in srgb, var(--btfw-color-text) 88%, #fff4c2 12%);
+  background: color-mix(in srgb, var(--btfw-color-accent) 16%, transparent 84%);
+  border: 1px solid color-mix(in srgb, var(--btfw-color-accent) 34%, transparent 66%);
   border-radius: 8px; padding: 8px 10px;
 }
 #btfw-gif-notice.is-hidden { display:none; }
@@ -477,13 +471,13 @@
   aspect-ratio: 1 / 1;        /* square */
   border-radius: 12px;
   overflow: hidden;
-  border: 1px solid rgba(255,255,255,.08);
-  background: rgba(255,255,255,.04);
+  border: 1px solid var(--btfw-border);
+  background: color-mix(in srgb, var(--btfw-color-panel) 82%, transparent 18%);
   cursor: pointer;
   padding: 0;
 }
-.btfw-gif-cell:hover { outline: 2px solid rgba(109,77,246,.45); }
-.btfw-gif-cell.is-broken { background: rgba(255, 102, 102, .15); }
+.btfw-gif-cell:hover { outline: 2px solid color-mix(in srgb, var(--btfw-color-accent) 56%, transparent 44%); }
+.btfw-gif-cell.is-broken { background: color-mix(in srgb, #ff6f96 70%, transparent 30%); }
 
 .btfw-gif-cell img {
   width: 100%; height: 100%;
@@ -493,7 +487,10 @@
 
 /* Skeleton tiles while loading */
 .btfw-gif-cell.is-skeleton {
-  background: linear-gradient(90deg, rgba(255,255,255,.04), rgba(255,255,255,.08), rgba(255,255,255,.04));
+  background: linear-gradient(90deg,
+    color-mix(in srgb, var(--btfw-color-panel) 78%, transparent 22%),
+    color-mix(in srgb, var(--btfw-color-panel) 88%, transparent 12%),
+    color-mix(in srgb, var(--btfw-color-panel) 78%, transparent 22%));
   background-size: 200% 100%;
   animation: btfw-shimmer 1s linear infinite;
 }
@@ -506,12 +503,12 @@
   margin-top: 14px;
   display:flex; align-items:center; gap:10px;
 }
-.btfw-gif-pages { color: #cfd8ea; min-width: 72px; text-align:center; }
+.btfw-gif-pages { color: var(--btfw-color-text-soft); min-width: 72px; text-align:center; }
 
 /* === Bulma-style skin for CyTube Bootstrap modals === */
 
 .modal-backdrop {
-  background: rgba(10,10,10,0.86) !important;
+  background: color-mix(in srgb, var(--btfw-color-bg) 86%, transparent 14%) !important;
 }
 
 .modal.btfw-bulma-skin {
@@ -525,17 +522,17 @@
 }
 
 .modal.btfw-bulma-skin .btfw-card {
-  background: #1f2a33;           /* dark card background */
-  color: #e7edf3;
-  border-radius: 12px;
-  border: 1px solid rgba(255,255,255,0.08);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.45);
+  background: var(--btfw-overlay-elevated);
+  color: var(--btfw-color-text);
+  border-radius: var(--btfw-radius);
+  border: 1px solid var(--btfw-border);
+  box-shadow: var(--btfw-overlay-shadow);
   overflow: auto;
 }
 
 .modal.btfw-bulma-skin .btfw-card-head {
-  background: rgba(255,255,255,0.035);
-  border-bottom: 1px solid rgba(255,255,255,0.08);
+  background: color-mix(in srgb, var(--btfw-overlay-bg) 92%, transparent 8%);
+  border-bottom: 1px solid var(--btfw-border);
   padding: 12px 16px;
   position: relative;
 }
@@ -554,8 +551,8 @@
 }
 
 .modal.btfw-bulma-skin .btfw-card-foot {
-  background: rgba(255,255,255,0.035);
-  border-top: 1px solid rgba(255,255,255,0.08);
+  background: color-mix(in srgb, var(--btfw-overlay-bg) 92%, transparent 8%);
+  border-top: 1px solid var(--btfw-border);
   padding: 10px 12px;
   display: flex;
   gap: 8px;
@@ -567,22 +564,34 @@
   border-radius: 8px;
 }
 .modal.btfw-bulma-skin .button.is-dark {
-  background: #2a3640; color: #dfe7ed; border: 1px solid rgba(255,255,255,0.08);
+  background: color-mix(in srgb, var(--btfw-color-panel) 88%, transparent 12%);
+  color: var(--btfw-color-text);
+  border: 1px solid var(--btfw-border);
 }
 .modal.btfw-bulma-skin .button.is-link {
-  background: #3a7bfd; color: #fff; border: none;
+  background: color-mix(in srgb, var(--btfw-color-accent) 88%, transparent 12%);
+  color: var(--btfw-color-on-accent);
+  border: none;
 }
 .modal.btfw-bulma-skin .button.is-danger {
-  background: #e05264; color: #fff; border: none;
+  background: color-mix(in srgb, #ff6f96 72%, var(--btfw-color-accent) 28%);
+  color: var(--btfw-color-on-accent);
+  border: none;
 }
 .modal.btfw-bulma-skin .button.is-warning {
-  background: #e0a84f; color: #1f2328; border: none;
+  background: color-mix(in srgb, #ffb347 72%, var(--btfw-color-accent) 28%);
+  color: color-mix(in srgb, var(--btfw-color-text) 68%, black 32%);
+  border: none;
 }
 .modal.btfw-bulma-skin .button.is-success {
-  background: #43b581; color: #0f1519; border: none;
+  background: color-mix(in srgb, #31ce8f 72%, var(--btfw-color-accent) 28%);
+  color: color-mix(in srgb, var(--btfw-color-text) 76%, black 24%);
+  border: none;
 }
 .modal.btfw-bulma-skin .button.is-info {
-  background: #2cb1bc; color: #0f1519; border: none;
+  background: color-mix(in srgb, #4ab8ff 72%, var(--btfw-color-accent) 28%);
+  color: color-mix(in srgb, var(--btfw-color-text) 76%, black 24%);
+  border: none;
 }
 
 /* Form elements inside skinned modals */
@@ -590,13 +599,13 @@
 .modal.btfw-bulma-skin input[type=password],
 .modal.btfw-bulma-skin select,
 .modal.btfw-bulma-skin textarea {
-  background: #172028;
-  color: #e7edf3;
-  border: 1px solid rgba(255,255,255,0.12);
+  background: color-mix(in srgb, var(--btfw-color-panel) 86%, transparent 14%);
+  color: var(--btfw-color-text);
+  border: 1px solid var(--btfw-border);
   border-radius: 8px;
   padding: 8px 10px;
 }
-.modal.btfw-bulma-skin label { color: #bcd1df; }
+.modal.btfw-bulma-skin label { color: var(--btfw-color-text-soft); }
 
 /* Make Bootstrap close(X) unobtrusive (we add Bulma .delete) */
 .modal.btfw-bulma-skin .close {
@@ -604,13 +613,15 @@
 }
 /* Emoji grid cells show a spinner until the <img> finishes */
 .btfw-emoji-grid { position:relative; display:grid; grid-template-columns: repeat(auto-fill, minmax(36px,1fr)); gap:8px; }
-.btfw-emoji-cell { position:relative; width:100%; padding-top:100%; border-radius:8px; overflow:hidden; background:rgba(255,255,255,.04); }
+.btfw-emoji-cell { position:relative; width:100%; padding-top:100%; border-radius:8px; overflow:hidden; background:color-mix(in srgb, var(--btfw-color-panel) 82%, transparent 18%); }
 .btfw-emoji-cell .btfw-emoji-img {
   position:absolute; inset:0; margin:auto; width:24px; height:24px; opacity:0; transition:opacity .12s linear;
 }
 .btfw-emoji-cell.loading::after {
   content:""; position:absolute; inset:0; margin:auto; width:18px; height:18px; border-radius:50%;
-  border:2px solid rgba(255,255,255,.2); border-top-color:var(--btfw-accent,#60a5fa); animation:btfw-spin 0.8s linear infinite;
+  border:2px solid color-mix(in srgb, var(--btfw-color-text) 20%, transparent 80%);
+  border-top-color: var(--btfw-color-accent);
+  animation:btfw-spin 0.8s linear infinite;
 }
 @keyframes btfw-spin { to { transform: rotate(360deg); } }
 .btfw-emoji-cell.ready .btfw-emoji-img { opacity:1; }
@@ -621,30 +632,30 @@ html[data-btfw-theme="dark"] {
 
 /* Modal */
 html[data-btfw-theme="dark"] .modal .modal-background {
-  background-color: rgba(8, 10, 14, 0.8) !important;
+  background-color: color-mix(in srgb, var(--btfw-color-bg) 86%, transparent 14%) !important;
 }
 html[data-btfw-theme="dark"] .modal-card {
-  background-color: #141a22 !important;
-  color: #e6edf3 !important;
-  box-shadow: 0 12px 38px rgba(0,0,0,.6);
+  background-color: var(--btfw-overlay-elevated) !important;
+  color: var(--btfw-color-text) !important;
+  box-shadow: var(--btfw-overlay-shadow);
 }
 html[data-btfw-theme="dark"] .modal-card-head,
 html[data-btfw-theme="dark"] .modal-card-foot {
-  background-color: #0f1620 !important;
-  border-color: #253142 !important;
-  color: #e6edf3 !important;
+  background-color: color-mix(in srgb, var(--btfw-overlay-bg) 96%, transparent 4%) !important;
+  border-color: var(--btfw-border) !important;
+  color: var(--btfw-color-text) !important;
 }
-html[data-btfw-theme="dark"] .modal-card-title { color: #e6edf3 !important; }
+html[data-btfw-theme="dark"] .modal-card-title { color: var(--btfw-color-text) !important; }
 
 /* Buttons inside modals (keeps your existing button styles) */
 html[data-btfw-theme="dark"] .button {
-  border-color: rgba(255,255,255,0.08);
+  border-color: var(--btfw-border);
 }
 html[data-btfw-theme="dark"] .button.is-link,
 html[data-btfw-theme="dark"] .button.is-primary {
-  background: #2563eb !important;
-  border-color: #2159d3 !important;
-  color: #fff !important;
+  background: color-mix(in srgb, var(--btfw-color-accent) 88%, transparent 12%) !important;
+  border-color: color-mix(in srgb, var(--btfw-color-accent) 62%, transparent 38%) !important;
+  color: var(--btfw-color-on-accent) !important;
 }
 
 /* Dropdowns, menus */
@@ -652,41 +663,41 @@ html[data-btfw-theme="dark"] .dropdown-content,
 html[data-btfw-theme="dark"] .menu,
 html[data-btfw-theme="dark"] .message,
 html[data-btfw-theme="dark"] .notification {
-  background-color: #141a22 !important;
-  color: #e6edf3 !important;
-  border: 1px solid #253142 !important;
+  background-color: var(--btfw-overlay-bg) !important;
+  color: var(--btfw-color-text) !important;
+  border: 1px solid var(--btfw-border) !important;
 }
 
 /* Forms */
 html[data-btfw-theme="dark"] .input,
 html[data-btfw-theme="dark"] .textarea,
 html[data-btfw-theme="dark"] .select select {
-  background-color: #0f1620 !important;
-  color: #e6edf3 !important;
-  border-color: #2b3a4a !important;
+  background-color: color-mix(in srgb, var(--btfw-color-panel) 86%, transparent 14%) !important;
+  color: var(--btfw-color-text) !important;
+  border-color: var(--btfw-border) !important;
 }
 html[data-btfw-theme="dark"] .input::placeholder,
 html[data-btfw-theme="dark"] .textarea::placeholder {
-  color: #9fb0c2 !important;
+  color: color-mix(in srgb, var(--btfw-color-text) 52%, transparent 48%) !important;
 }
 
 /* Tabs */
 html[data-btfw-theme="dark"] .tabs.is-boxed li.is-active a {
-  background-color: #0f1620 !important;
-  border-color: #253142 !important;
-  color: #e6edf3 !important;
+  background-color: color-mix(in srgb, var(--btfw-color-accent) 34%, transparent 66%) !important;
+  border-color: color-mix(in srgb, var(--btfw-color-accent) 56%, transparent 44%) !important;
+  color: var(--btfw-color-on-accent) !important;
 }
 html[data-btfw-theme="dark"] .tabs a {
-  color: #c8d4e0 !important;
+  color: var(--btfw-color-text-muted) !important;
 }
 
 /* Generic surfaces (if used) */
 html[data-btfw-theme="dark"] .box,
 html[data-btfw-theme="dark"] .card,
 html[data-btfw-theme="dark"] .panel {
-  background-color: #141a22 !important;
-  color: #e6edf3 !important;
-  border: 1px solid #253142 !important;
+  background-color: var(--btfw-overlay-bg) !important;
+  color: var(--btfw-color-text) !important;
+  border: 1px solid var(--btfw-border) !important;
 }
 /* --- BTFW notify (sticky toasts in #messagebuffer) --- */
 #messagebuffer { position: relative; }
@@ -708,50 +719,50 @@ html[data-btfw-theme="dark"] .panel {
 .btfw-notice{
   pointer-events: auto;
   width: 100%;
-  background: var(--btfw-notice-bg, rgba(14,22,30,0.96));
-  color: var(--btfw-notice-text, #f4f8ff);
-  border: 1px solid var(--btfw-notice-border, rgba(255,255,255,0.08));
+  background: var(--btfw-notice-bg, color-mix(in srgb, var(--btfw-overlay-bg) 96%, transparent 4%));
+  color: var(--btfw-notice-text, var(--btfw-color-text));
+  border: 1px solid var(--btfw-notice-border, var(--btfw-border));
   border-radius: 16px;
-  box-shadow: 0 18px 32px rgba(4,10,18,0.52);
+  box-shadow: 0 18px 32px color-mix(in srgb, var(--btfw-color-bg) 52%, transparent 48%);
   backdrop-filter: blur(14px);
   overflow: hidden;
   animation: btfw-nt-in .16s ease-out;
-  --btfw-notice-accent: #4a9eff;
-  --btfw-notice-icon-bg: rgba(74, 158, 255, 0.18);
-  --btfw-notice-icon-color: #d2e6ff;
-  --btfw-notice-muted: rgba(223,231,242,0.78);
+  --btfw-notice-accent: color-mix(in srgb, var(--btfw-color-accent) 70%, #4a9eff 30%);
+  --btfw-notice-icon-bg: color-mix(in srgb, var(--btfw-color-accent) 26%, transparent 74%);
+  --btfw-notice-icon-color: color-mix(in srgb, var(--btfw-color-on-accent) 88%, white 12%);
+  --btfw-notice-muted: color-mix(in srgb, var(--btfw-color-text) 68%, transparent 32%);
 }
 
 .btfw-notice--info{
-  --btfw-notice-bg: rgba(16,32,46,0.95);
-  --btfw-notice-border: rgba(88,138,255,0.32);
-  --btfw-notice-accent: #5aa2ff;
-  --btfw-notice-icon-bg: rgba(90,162,255,0.18);
-  --btfw-notice-icon-color: #d4e5ff;
+  --btfw-notice-bg: color-mix(in srgb, var(--btfw-color-accent) 22%, transparent 78%);
+  --btfw-notice-border: color-mix(in srgb, var(--btfw-color-accent) 42%, transparent 58%);
+  --btfw-notice-accent: color-mix(in srgb, var(--btfw-color-accent) 70%, #5aa2ff 30%);
+  --btfw-notice-icon-bg: color-mix(in srgb, var(--btfw-color-accent) 28%, transparent 72%);
+  --btfw-notice-icon-color: color-mix(in srgb, var(--btfw-color-on-accent) 92%, white 8%);
 }
 
 .btfw-notice--success{
-  --btfw-notice-bg: #11281f;
-  --btfw-notice-border: rgba(66,195,134,0.36);
-  --btfw-notice-accent: #31ce8f;
-  --btfw-notice-icon-bg: rgba(66,195,134,0.18);
-  --btfw-notice-icon-color: #bcf3db;
+  --btfw-notice-bg: color-mix(in srgb, #31ce8f 38%, var(--btfw-color-panel) 62%);
+  --btfw-notice-border: color-mix(in srgb, #31ce8f 48%, var(--btfw-color-accent) 52%);
+  --btfw-notice-accent: color-mix(in srgb, #31ce8f 70%, var(--btfw-color-accent) 30%);
+  --btfw-notice-icon-bg: color-mix(in srgb, #31ce8f 26%, transparent 74%);
+  --btfw-notice-icon-color: color-mix(in srgb, var(--btfw-color-on-accent) 88%, #dff7eb 12%);
 }
 
 .btfw-notice--warn{
-  --btfw-notice-bg: #2c210f;
-  --btfw-notice-border: rgba(255,184,90,0.34);
-  --btfw-notice-accent: #ffb347;
-  --btfw-notice-icon-bg: rgba(255,184,90,0.2);
-  --btfw-notice-icon-color: #ffe2bc;
+  --btfw-notice-bg: color-mix(in srgb, #ffb347 36%, var(--btfw-color-panel) 64%);
+  --btfw-notice-border: color-mix(in srgb, #ffb347 48%, var(--btfw-color-accent) 52%);
+  --btfw-notice-accent: color-mix(in srgb, #ffb347 70%, var(--btfw-color-accent) 30%);
+  --btfw-notice-icon-bg: color-mix(in srgb, #ffb347 26%, transparent 74%);
+  --btfw-notice-icon-color: color-mix(in srgb, var(--btfw-color-on-accent) 80%, #ffe9c8 20%);
 }
 
 .btfw-notice--error{
-  --btfw-notice-bg: #2f1821;
-  --btfw-notice-border: rgba(255,114,146,0.36);
-  --btfw-notice-accent: #ff6f96;
-  --btfw-notice-icon-bg: rgba(255,114,146,0.22);
-  --btfw-notice-icon-color: #ffd5df;
+  --btfw-notice-bg: color-mix(in srgb, #ff6f96 36%, var(--btfw-color-panel) 64%);
+  --btfw-notice-border: color-mix(in srgb, #ff6f96 48%, var(--btfw-color-accent) 52%);
+  --btfw-notice-accent: color-mix(in srgb, #ff6f96 70%, var(--btfw-color-accent) 30%);
+  --btfw-notice-icon-bg: color-mix(in srgb, #ff6f96 26%, transparent 74%);
+  --btfw-notice-icon-color: color-mix(in srgb, var(--btfw-color-on-accent) 86%, #ffe0ea 14%);
 }
 
 .btfw-notice-shell{
@@ -805,8 +816,8 @@ html[data-btfw-theme="dark"] .panel {
   height: 28px;
   border-radius: 999px;
   border: 0;
-  background: rgba(255,255,255,0.04);
-  color: rgba(255,255,255,0.78);
+  background: color-mix(in srgb, var(--btfw-color-panel) 80%, transparent 20%);
+  color: var(--btfw-color-text-soft);
   cursor: pointer;
   font-size: 18px;
   line-height: 1;
@@ -815,8 +826,8 @@ html[data-btfw-theme="dark"] .panel {
 
 .btfw-notice-close:hover,
 .btfw-notice-close:focus{
-  background: rgba(255,255,255,0.12);
-  color: #fff;
+  background: color-mix(in srgb, var(--btfw-notice-accent) 34%, transparent 66%);
+  color: var(--btfw-color-on-accent);
 }
 
 .btfw-notice-body{
@@ -837,15 +848,15 @@ html[data-btfw-theme="dark"] .panel {
   padding: 8px 16px;
   font-weight: 600;
   font-size: 13px;
-  background: rgba(255,255,255,0.1);
-  color: #fff;
+  background: color-mix(in srgb, var(--btfw-notice-accent) 24%, transparent 76%);
+  color: var(--btfw-color-on-accent);
   cursor: pointer;
   transition: background .16s ease, transform .16s ease;
 }
 
 .btfw-notice-cta:hover,
 .btfw-notice-cta:focus{
-  background: rgba(255,255,255,0.18);
+  background: color-mix(in srgb, var(--btfw-notice-accent) 36%, transparent 64%);
   transform: translateY(-1px);
 }
 
@@ -859,7 +870,7 @@ html[data-btfw-theme="dark"] .panel {
 }
 
 .btfw-notice-timer.is-stopped{
-  color: rgba(244,248,255,0.9);
+  color: color-mix(in srgb, var(--btfw-color-text) 92%, white 8%);
 }
 
 .btfw-notice-stop{
@@ -879,7 +890,7 @@ html[data-btfw-theme="dark"] .panel {
 
 .btfw-notice-progress{
   height: 3px;
-  background: rgba(255,255,255,0.1);
+  background: color-mix(in srgb, var(--btfw-color-text) 16%, transparent 84%);
 }
 
 .btfw-notice-progress > div{
@@ -887,7 +898,7 @@ html[data-btfw-theme="dark"] .panel {
   width: 100%;
   transform-origin: left;
   transform: scaleX(1);
-  background: linear-gradient(90deg, var(--btfw-notice-accent), rgba(255,255,255,0));
+  background: linear-gradient(90deg, var(--btfw-notice-accent), color-mix(in srgb, var(--btfw-notice-accent) 12%, transparent 88%));
   transition: transform .14s linear;
 }
 
@@ -909,8 +920,10 @@ html[data-btfw-theme="dark"] .panel {
   display: none;
   z-index: 4000;
   max-width: min(90vw, 420px);
-  box-shadow: 0 8px 24px rgba(0,0,0,.3);
-  border-radius: 1rem; /* 2xl-ish */
+  background: var(--btfw-overlay-bg);
+  border: 1px solid var(--btfw-border);
+  box-shadow: var(--btfw-overlay-shadow);
+  border-radius: calc(var(--btfw-radius) + 4px);
   overflow: hidden;
 }
 .btfw-pop.btfw-pop--open{ display: block; }

--- a/css/player.css
+++ b/css/player.css
@@ -17,8 +17,8 @@
   display: block;
   overflow: hidden;
   aspect-ratio: var(--btfw-video-aspect, 16 / 9);
-  background: #000;
-  border-radius: 12px;
+  background: var(--btfw-video-bg);
+  border-radius: var(--btfw-radius);
 }
 #videowrap .embed-responsive::before{
   content: "";
@@ -48,8 +48,8 @@
   aspect-ratio: var(--btfw-video-aspect, 16 / 9);
   border: 0;
   display: block;
-  background: #000;
-  border-radius: 12px;
+  background: var(--btfw-video-bg);
+  border-radius: var(--btfw-radius);
 }
 
 /* Video overlay buttons are styled in overlays.css; ensure interactivity */

--- a/css/tokens.css
+++ b/css/tokens.css
@@ -1,1 +1,33 @@
-:root{--btfw-top:48px;--btfw-border:rgba(255,255,255,.08);}
+:root {
+  --btfw-top: 48px;
+  --btfw-gap: 10px;
+  --btfw-color-bg: var(--btfw-theme-bg, #0f1524);
+  --btfw-color-surface: var(--btfw-theme-surface, #151d30);
+  --btfw-color-panel: var(--btfw-theme-panel, #1d2640);
+  --btfw-color-text: var(--btfw-theme-text, #e6edf3);
+  --btfw-color-chat-text: var(--btfw-theme-chat-text, var(--btfw-color-text));
+  --btfw-color-accent: var(--btfw-theme-accent, #6d4df6);
+  --btfw-color-on-accent: color-mix(in srgb, var(--btfw-color-text) 94%, white 6%);
+  --btfw-color-text-soft: color-mix(in srgb, var(--btfw-color-text) 82%, transparent 18%);
+  --btfw-color-text-muted: color-mix(in srgb, var(--btfw-color-text) 62%, transparent 38%);
+  --btfw-border: color-mix(in srgb, var(--btfw-color-accent) 26%, transparent 74%);
+  --btfw-card-bg: color-mix(in srgb, var(--btfw-color-panel) 88%, transparent 12%);
+  --btfw-radius: 12px;
+  --btfw-chat-min: 320px;
+  --btfw-chat-max: 30vw;
+  --btfw-split-width: 8px;
+  --btfw-overlay-bg: color-mix(in srgb, var(--btfw-color-panel) 92%, transparent 8%);
+  --btfw-overlay-elevated: color-mix(in srgb, var(--btfw-color-surface) 92%, transparent 8%);
+  --btfw-overlay-border: color-mix(in srgb, var(--btfw-color-accent) 22%, transparent 78%);
+  --btfw-overlay-shadow: 0 18px 48px color-mix(in srgb, var(--btfw-color-bg) 58%, transparent 42%),
+    0 4px 12px color-mix(in srgb, var(--btfw-color-bg) 42%, transparent 58%);
+  --btfw-glass-bg: color-mix(in srgb, var(--btfw-color-bg) 88%, transparent 12%);
+  --btfw-glass-border: color-mix(in srgb, var(--btfw-color-accent) 18%, transparent 82%);
+  --btfw-glass-shadow: 0 14px 40px color-mix(in srgb, var(--btfw-color-bg) 55%, transparent 45%);
+  --btfw-scrollbar-thumb: color-mix(in srgb, var(--btfw-color-text) 22%, transparent 78%);
+  --btfw-scrollbar-thumb-hover: color-mix(in srgb, var(--btfw-color-accent) 32%, transparent 68%);
+  --btfw-chip-bg: color-mix(in srgb, var(--btfw-color-accent) 20%, transparent 80%);
+  --btfw-chip-bg-hover: color-mix(in srgb, var(--btfw-color-accent) 32%, transparent 68%);
+  --btfw-chip-text: color-mix(in srgb, var(--btfw-color-text) 94%, white 6%);
+  --btfw-video-bg: color-mix(in srgb, var(--btfw-color-bg) 45%, black 55%);
+}

--- a/modules/feature-channels.js
+++ b/modules/feature-channels.js
@@ -1,20 +1,51 @@
 BTFW.define("feature:channels", [], async () => {
   const $ = (s, r = document) => r.querySelector(s);
 
-  function isChannelListEnabled() {
+  function resolveSliderSettings() {
     try {
-      return window.UI_ChannelList === "1" || window.UI_ChannelList === 1;
+      const global = window.BTFW || {};
+      const theme = global.channelTheme || {};
+      const slider = theme.slider || {};
+      let enabled = slider.enabled;
+      let url = slider.feedUrl || slider.url || slider.json || '';
+
+      if (typeof enabled === 'undefined' && typeof theme.sliderEnabled !== 'undefined') {
+        enabled = theme.sliderEnabled;
+      }
+      if (!url) {
+        url = theme.sliderJson || theme.sliderJSON || '';
+      }
+
+      if (typeof enabled === 'undefined' && global.channelSlider) {
+        enabled = global.channelSlider.enabled;
+        if (!url) url = global.channelSlider.feedUrl || '';
+      }
+      if (typeof enabled === 'undefined' && typeof global.channelSliderEnabled !== 'undefined') {
+        enabled = global.channelSliderEnabled;
+      }
+      if (!url && global.channelSliderJSON) {
+        url = global.channelSliderJSON;
+      }
+
+      if (typeof enabled === 'undefined' && typeof window.UI_ChannelList !== 'undefined') {
+        enabled = window.UI_ChannelList === '1' || window.UI_ChannelList === 1;
+      }
+      if (!url && typeof window.Channel_JSON !== 'undefined') {
+        url = window.Channel_JSON || '';
+      }
+
+      return { enabled: Boolean(enabled), url: url || '' };
     } catch (_) {
-      return false;
+      return { enabled: false, url: '' };
     }
   }
 
+  function isChannelListEnabled() {
+    return resolveSliderSettings().enabled;
+  }
+
   function getChannelJSON() {
-    try {
-      return window.Channel_JSON || '';
-    } catch (_) {
-      return '';
-    }
+    return resolveSliderSettings().url || '';
   }
 
   function createChannelSlider(channels) {
@@ -98,15 +129,21 @@ BTFW.define("feature:channels", [], async () => {
       .btfw-channels {
         position: relative;
         margin-top: 10px;
-        border-radius: 14px;
-        border: 1px solid rgba(255, 255, 255, 0.08);
-        background: linear-gradient(135deg, rgba(16, 20, 30, 0.92), rgba(20, 28, 42, 0.92));
+        border-radius: 16px;
+        border: 1px solid rgba(109, 77, 246, 0.22);
+        border: 1px solid color-mix(in srgb, var(--btfw-theme-accent, #6d4df6) 28%, transparent 72%);
+        background: rgba(20, 28, 42, 0.92);
+        background: linear-gradient(135deg,
+          color-mix(in srgb, var(--btfw-theme-surface, #151d30) 94%, transparent 6%),
+          color-mix(in srgb, var(--btfw-theme-panel, #1d2640) 86%, black 14%));
         padding: 18px 52px;
         display: flex;
         align-items: center;
         gap: 14px;
         width: 100%;
-        box-shadow: 0 20px 36px rgba(4, 8, 16, 0.45);
+        color: var(--btfw-theme-text, #e6edf3);
+        box-shadow: 0 24px 48px color-mix(in srgb, var(--btfw-theme-bg, #0f1524) 30%, transparent 70%);
+        backdrop-filter: blur(14px);
       }
 
       .btfw-channels__viewport {
@@ -131,13 +168,13 @@ BTFW.define("feature:channels", [], async () => {
         flex-direction: column;
         gap: 8px;
         text-decoration: none;
-        color: inherit;
-        background: rgba(255, 255, 255, 0.04);
+        color: color-mix(in srgb, var(--btfw-theme-text, #e6edf3) 96%, transparent 4%);
+        background: color-mix(in srgb, var(--btfw-theme-surface, #151d30) 88%, transparent 12%);
         border-radius: 12px;
-        border: 1px solid rgba(255, 255, 255, 0.07);
+        border: 1px solid color-mix(in srgb, var(--btfw-theme-accent, #6d4df6) 22%, transparent 78%);
         overflow: hidden;
-        box-shadow: 0 10px 24px rgba(0,0,0,0.35);
-        transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+        box-shadow: 0 14px 30px color-mix(in srgb, var(--btfw-theme-panel, #1d2640) 28%, transparent 72%);
+        transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease, background 0.18s ease;
         cursor: grab;
         user-select: none;
       }
@@ -145,15 +182,16 @@ BTFW.define("feature:channels", [], async () => {
       .btfw-channels__link:hover,
       .btfw-channels__link:focus {
         transform: translateY(-4px);
-        border-color: rgba(109, 77, 246, 0.6);
-        box-shadow: 0 16px 30px rgba(109, 77, 246, 0.32);
+        border-color: color-mix(in srgb, var(--btfw-theme-accent, #6d4df6) 70%, white 30%);
+        background: color-mix(in srgb, var(--btfw-theme-panel, #1d2640) 82%, var(--btfw-theme-accent, #6d4df6) 18%);
+        box-shadow: 0 18px 36px color-mix(in srgb, var(--btfw-theme-accent, #6d4df6) 35%, transparent 65%);
       }
 
       .btfw-channels__media {
         position: relative;
         aspect-ratio: 16 / 9;
         overflow: hidden;
-        background: rgba(12,16,24,0.9);
+        background: color-mix(in srgb, var(--btfw-theme-panel, #1d2640) 88%, black 12%);
       }
 
       .btfw-channels__thumb {
@@ -165,7 +203,7 @@ BTFW.define("feature:channels", [], async () => {
       }
 
       .btfw-channels__thumb.is-missing {
-        opacity: 0.4;
+        opacity: 0.45;
         object-fit: contain;
       }
 
@@ -178,7 +216,7 @@ BTFW.define("feature:channels", [], async () => {
         font-weight: 600;
         letter-spacing: 0.01em;
         font-size: 14px;
-        color: rgba(232, 236, 248, 0.92);
+        color: color-mix(in srgb, var(--btfw-theme-text, #e6edf3) 92%, transparent 8%);
         text-overflow: ellipsis;
         overflow: hidden;
         white-space: nowrap;
@@ -192,15 +230,16 @@ BTFW.define("feature:channels", [], async () => {
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        background: rgba(255,255,255,0.12);
-        color: #fff;
+        background: color-mix(in srgb, var(--btfw-theme-accent, #6d4df6) 18%, rgba(255,255,255,0.08) 82%);
+        color: color-mix(in srgb, var(--btfw-theme-text, #e6edf3) 98%, transparent 2%);
         font-size: 20px;
         cursor: pointer;
-        transition: background 0.2s ease, transform 0.2s ease;
+        transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
       }
 
       .btfw-channels__arrow:hover:not([disabled]) {
-        background: rgba(109, 77, 246, 0.9);
+        background: color-mix(in srgb, var(--btfw-theme-accent, #6d4df6) 65%, white 35%);
+        box-shadow: 0 12px 24px color-mix(in srgb, var(--btfw-theme-accent, #6d4df6) 30%, transparent 70%);
         transform: translateY(-2px);
       }
 
@@ -216,7 +255,7 @@ BTFW.define("feature:channels", [], async () => {
 
       .btfw-channels__empty {
         padding: 24px;
-        color: rgba(235, 238, 247, 0.7);
+        color: color-mix(in srgb, var(--btfw-theme-text, #e6edf3) 80%, transparent 20%);
         font-size: 15px;
         width: 100%;
         text-align: center;

--- a/modules/feature_channels.js
+++ b/modules/feature_channels.js
@@ -1,20 +1,51 @@
 BTFW.define("feature:channels", [], async () => {
   const $ = (s, r = document) => r.querySelector(s);
 
-  function isChannelListEnabled() {
+  function resolveSliderSettings() {
     try {
-      return window.UI_ChannelList === "1" || window.UI_ChannelList === 1;
+      const global = window.BTFW || {};
+      const theme = global.channelTheme || {};
+      const slider = theme.slider || {};
+      let enabled = slider.enabled;
+      let url = slider.feedUrl || slider.url || slider.json || '';
+
+      if (typeof enabled === 'undefined' && typeof theme.sliderEnabled !== 'undefined') {
+        enabled = theme.sliderEnabled;
+      }
+      if (!url) {
+        url = theme.sliderJson || theme.sliderJSON || '';
+      }
+
+      if (typeof enabled === 'undefined' && global.channelSlider) {
+        enabled = global.channelSlider.enabled;
+        if (!url) url = global.channelSlider.feedUrl || '';
+      }
+      if (typeof enabled === 'undefined' && typeof global.channelSliderEnabled !== 'undefined') {
+        enabled = global.channelSliderEnabled;
+      }
+      if (!url && global.channelSliderJSON) {
+        url = global.channelSliderJSON;
+      }
+
+      if (typeof enabled === 'undefined' && typeof window.UI_ChannelList !== 'undefined') {
+        enabled = window.UI_ChannelList === '1' || window.UI_ChannelList === 1;
+      }
+      if (!url && typeof window.Channel_JSON !== 'undefined') {
+        url = window.Channel_JSON || '';
+      }
+
+      return { enabled: Boolean(enabled), url: url || '' };
     } catch (_) {
-      return false;
+      return { enabled: false, url: '' };
     }
   }
 
+  function isChannelListEnabled() {
+    return resolveSliderSettings().enabled;
+  }
+
   function getChannelJSON() {
-    try {
-      return window.Channel_JSON || '';
-    } catch (_) {
-      return '';
-    }
+    return resolveSliderSettings().url || '';
   }
 
   function createChannelSlider(channels) {
@@ -52,11 +83,13 @@ BTFW.define("feature:channels", [], async () => {
       .slider {
         position: relative;
         margin: 10px 0;
-        background: rgba(20, 24, 34, 0.92);
-        border: 1px solid rgba(255, 255, 255, 0.08);
-        border-radius: 12px;
+        background: color-mix(in srgb, var(--btfw-theme-panel, #1d2640) 86%, transparent 14%);
+        border: 1px solid color-mix(in srgb, var(--btfw-theme-accent, #6d4df6) 24%, transparent 76%);
+        border-radius: 14px;
         overflow: hidden;
         height: 120px;
+        color: var(--btfw-theme-text, #e6edf3);
+        box-shadow: 0 18px 36px color-mix(in srgb, var(--btfw-theme-bg, #0f1524) 28%, transparent 72%);
       }
       
       .carousel-inner {
@@ -73,16 +106,17 @@ BTFW.define("feature:channels", [], async () => {
         flex: 0 0 140px;
         height: 80px;
         cursor: pointer;
-        border-radius: 8px;
+        border-radius: 10px;
         overflow: hidden;
-        transition: transform 0.2s ease, box-shadow 0.2s ease;
-        border: 1px solid rgba(255, 255, 255, 0.08);
+        transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+        border: 1px solid color-mix(in srgb, var(--btfw-theme-accent, #6d4df6) 18%, transparent 82%);
+        background: color-mix(in srgb, var(--btfw-theme-surface, #151d30) 84%, transparent 16%);
       }
-      
+
       .item:hover {
         transform: translateY(-2px);
-        box-shadow: 0 4px 12px rgba(109, 77, 246, 0.15);
-        border-color: rgba(109, 77, 246, 0.4);
+        box-shadow: 0 8px 16px color-mix(in srgb, var(--btfw-theme-accent, #6d4df6) 30%, transparent 70%);
+        border-color: color-mix(in srgb, var(--btfw-theme-accent, #6d4df6) 65%, white 35%);
       }
       
       .item img.kek {
@@ -102,8 +136,8 @@ BTFW.define("feature:channels", [], async () => {
         top: 50%;
         transform: translateY(-50%);
         font-size: 24px;
-        color: #fff;
-        background: rgba(109, 77, 246, 0.8);
+        color: color-mix(in srgb, var(--btfw-theme-text, #e6edf3) 98%, transparent 2%);
+        background: color-mix(in srgb, var(--btfw-theme-accent, #6d4df6) 32%, rgba(0,0,0,0.55) 68%);
         width: 40px;
         height: 40px;
         border-radius: 50%;
@@ -115,10 +149,11 @@ BTFW.define("feature:channels", [], async () => {
         transition: all 0.2s ease;
         user-select: none;
       }
-      
+
       .arrow:hover {
-        background: rgba(109, 77, 246, 1);
+        background: color-mix(in srgb, var(--btfw-theme-accent, #6d4df6) 70%, white 30%);
         transform: translateY(-50%) scale(1.1);
+        box-shadow: 0 10px 24px color-mix(in srgb, var(--btfw-theme-accent, #6d4df6) 32%, transparent 68%);
       }
       
       .arrleft {


### PR DESCRIPTION
## Summary
- expand `tokens.css` with reusable palette tokens for overlays, chips, scrollbars, and video surfaces
- update chat, overlays, mobile, and player styles to consume the new variables so admin tint changes sync to generated CSS
- refresh modal, popover, and notice treatments to rely on palette color-mix values while preserving Bulma/Bootstrap bridges

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4fdd377348329941192d3bd8b866f