### PR TITLE
Refine navbar, theme modal, and TMDB integration

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -23,6 +23,11 @@ body {
   text-rendering: optimizeLegibility;
 }
 
+html, body, #wrap, .container, .container-fluid, .navbar, .modal, .panel, .card, .box,
+.btn, button, input, select, textarea, .dropdown-menu, .well {
+  font-family: var(--btfw-font-body) !important;
+}
+
 body::after {
   content: "";
   position: fixed;
@@ -120,12 +125,34 @@ a:hover {
 #btfw-grid{
   display: grid;
   grid-template-columns: minmax(520px,1fr) var(--btfw-split-width) minmax(var(--btfw-chat-min),var(--btfw-chat-max));
-  grid-template-areas: "video split chat";
+  grid-template-areas:
+    "nav nav nav"
+    "video split chat";
+  grid-template-rows: auto 1fr;
   grid-column-gap: var(--btfw-gap);
   grid-row-gap: var(--btfw-gap);
-  margin-top: calc(var(--btfw-top) + var(--btfw-gap));
-  padding: 0 var(--btfw-gap);
+  margin-top: 0;
+  padding: 0 var(--btfw-gap) var(--btfw-gap);
   min-height: calc(100vh - var(--btfw-top) - var(--btfw-gap)); /* Ensure full height */
+  position: relative;
+  z-index: 0;
+}
+
+#btfw-navhost{
+  grid-area: nav;
+  position: relative;
+  min-height: var(--btfw-top);
+  padding-top: 0;
+  padding-bottom: var(--btfw-gap);
+  overflow: visible;
+}
+
+#btfw-navhost::before{
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: 0;
 }
 
 #btfw-leftpad{
@@ -159,21 +186,26 @@ a:hover {
 /* Allow swapping chat/video positions on desktop */
 #btfw-grid.btfw-grid--chat-left{
   grid-template-columns: minmax(var(--btfw-chat-min),var(--btfw-chat-max)) var(--btfw-split-width) minmax(520px,1fr);
-  grid-template-areas: "chat split video";
+  grid-template-areas:
+    "nav nav nav"
+    "chat split video";
 }
 
 #btfw-grid.btfw-grid--chat-right{
   grid-template-columns: minmax(520px,1fr) var(--btfw-split-width) minmax(var(--btfw-chat-min),var(--btfw-chat-max));
-  grid-template-areas: "video split chat";
+  grid-template-areas:
+    "nav nav nav"
+    "video split chat";
 }
 
 /* Vertical (mobile) layout with video stacked above chat */
 #btfw-grid.btfw-grid--vertical{
   grid-template-columns: 1fr;
   grid-template-areas:
+    "nav"
     "video"
     "chat";
-  grid-template-rows: auto 1fr;
+  grid-template-rows: auto auto auto;
   grid-row-gap: var(--btfw-gap);
   min-height: calc(100vh - var(--btfw-top) - var(--btfw-gap));
   height: auto;
@@ -501,6 +533,232 @@ a:hover {
   text-align: right;
   font-variant-numeric: tabular-nums;
   color: color-mix(in srgb, var(--btfw-color-text) 88%, transparent 12%);
+}
+
+#btfw-theme-modal .modal-card,
+#btfw-theme-modal .btfw-theme-modal-card{
+  width: min(920px, 94vw);
+  background: color-mix(in srgb, var(--btfw-color-surface) 96%, transparent 4%);
+  border: 1px solid color-mix(in srgb, var(--btfw-border) 85%, transparent 15%);
+  border-radius: 26px;
+  box-shadow:
+    0 32px 64px color-mix(in srgb, var(--btfw-color-bg) 60%, transparent 40%),
+    0 12px 28px color-mix(in srgb, var(--btfw-color-bg) 45%, transparent 55%);
+  color: var(--btfw-color-text);
+  overflow: hidden;
+}
+
+#btfw-theme-modal .modal-card-head,
+#btfw-theme-modal .modal-card-foot{
+  background: color-mix(in srgb, var(--btfw-color-panel) 90%, transparent 10%);
+  border-color: color-mix(in srgb, var(--btfw-border) 80%, transparent 20%);
+  color: var(--btfw-color-text);
+}
+
+#btfw-theme-modal .modal-card-title{
+  font-size: 1.25rem;
+  letter-spacing: 0.04em;
+  font-weight: 700;
+}
+
+#btfw-theme-modal .modal-card-body{
+  background: color-mix(in srgb, var(--btfw-color-surface) 94%, transparent 6%);
+  padding: 24px 28px 30px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+#btfw-theme-modal .btfw-ts-tabs{
+  border-bottom: 0;
+  margin-bottom: 4px;
+}
+
+#btfw-theme-modal .btfw-ts-tabs ul{
+  display: inline-flex;
+  gap: 8px;
+}
+
+#btfw-theme-modal .btfw-ts-tabs li{
+  margin: 0;
+}
+
+#btfw-theme-modal .btfw-ts-tabs li a{
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: color-mix(in srgb, var(--btfw-color-panel) 80%, transparent 20%);
+  color: color-mix(in srgb, var(--btfw-color-text) 82%, transparent 18%);
+  padding: 8px 18px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+#btfw-theme-modal .btfw-ts-tabs li.is-active a{
+  background: var(--btfw-navbar-pill-bg);
+  color: var(--btfw-navbar-pill-text);
+  border-color: color-mix(in srgb, var(--btfw-border) 80%, transparent 20%);
+  box-shadow: 0 12px 28px color-mix(in srgb, var(--btfw-color-accent) 32%, transparent 68%);
+}
+
+#btfw-theme-modal .btfw-ts-grid{
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+#btfw-theme-modal .btfw-ts-card{
+  background: color-mix(in srgb, var(--btfw-color-panel) 92%, transparent 8%);
+  border: 1px solid color-mix(in srgb, var(--btfw-border) 78%, transparent 22%);
+  border-radius: 20px;
+  padding: 20px 22px;
+  box-shadow:
+    0 24px 48px color-mix(in srgb, var(--btfw-color-bg) 55%, transparent 45%),
+    inset 0 1px 0 color-mix(in srgb, var(--btfw-color-text) 8%, transparent 92%);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+#btfw-theme-modal .btfw-ts-card__header h3{
+  margin: 0;
+  font-size: 0.85rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--btfw-color-text) 78%, transparent 22%);
+}
+
+#btfw-theme-modal .btfw-ts-card__header p{
+  margin: 6px 0 0;
+  font-size: 0.85rem;
+  color: color-mix(in srgb, var(--btfw-color-text) 60%, transparent 40%);
+}
+
+#btfw-theme-modal .btfw-ts-card__body{
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+#btfw-theme-modal .btfw-ts-control{
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+#btfw-theme-modal .btfw-ts-control--radios .radio{
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: color-mix(in srgb, var(--btfw-color-text) 85%, transparent 15%);
+}
+
+#btfw-theme-modal .btfw-ts-control--radios .radio input{
+  margin: 0;
+  accent-color: var(--btfw-color-accent);
+}
+
+#btfw-theme-modal .btfw-input{
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+#btfw-theme-modal .btfw-input__label{
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--btfw-color-text) 68%, transparent 32%);
+}
+
+#btfw-theme-modal .btfw-input input[type="text"]{
+  background: color-mix(in srgb, var(--btfw-color-bg) 82%, transparent 18%);
+  border: 1px solid color-mix(in srgb, var(--btfw-border) 82%, transparent 18%);
+  border-radius: 12px;
+  padding: 10px 14px;
+  color: var(--btfw-color-text);
+  font-size: 0.92rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+#btfw-theme-modal .btfw-input input[type="text"]:focus{
+  border-color: color-mix(in srgb, var(--btfw-color-accent) 60%, transparent 40%);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--btfw-color-accent) 28%, transparent 72%);
+  outline: none;
+}
+
+#btfw-theme-modal .btfw-help{
+  margin: 0;
+  font-size: 0.8rem;
+  color: color-mix(in srgb, var(--btfw-color-text) 55%, transparent 45%);
+}
+
+#btfw-theme-modal .btfw-checkbox{
+  display: inline-flex;
+  align-items: flex-start;
+  gap: 10px;
+  font-weight: 600;
+  color: color-mix(in srgb, var(--btfw-color-text) 82%, transparent 18%);
+}
+
+#btfw-theme-modal .btfw-checkbox input{
+  width: 18px;
+  height: 18px;
+  accent-color: var(--btfw-color-accent);
+  margin-top: 2px;
+}
+
+#btfw-theme-modal .select select{
+  background: color-mix(in srgb, var(--btfw-color-bg) 82%, transparent 18%);
+  border: 1px solid color-mix(in srgb, var(--btfw-border) 80%, transparent 20%);
+  color: var(--btfw-color-text);
+  border-radius: 10px;
+}
+
+#btfw-theme-modal .modal-card-foot{
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+#btfw-theme-modal .modal-card-foot .button{
+  border-radius: 12px;
+  padding: 10px 18px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+#btfw-theme-modal .modal-card-foot .button.is-link{
+  background: var(--btfw-navbar-pill-bg);
+  border: 0;
+  color: var(--btfw-navbar-pill-text);
+  box-shadow: 0 18px 36px color-mix(in srgb, var(--btfw-color-accent) 32%, transparent 68%);
+}
+
+#btfw-theme-modal .modal-card-foot .button:not(.is-link){
+  background: color-mix(in srgb, var(--btfw-color-bg) 78%, transparent 22%);
+  border: 1px solid color-mix(in srgb, var(--btfw-border) 70%, transparent 30%);
+  color: color-mix(in srgb, var(--btfw-color-text) 80%, transparent 20%);
+}
+
+#btfw-theme-modal code{
+  background: color-mix(in srgb, var(--btfw-color-bg) 70%, transparent 30%);
+  border-radius: 6px;
+  padding: 2px 6px;
+  color: color-mix(in srgb, var(--btfw-color-text) 90%, transparent 10%);
+}
+
+@media (max-width: 720px){
+  #btfw-theme-modal .btfw-ts-grid{
+    grid-template-columns: 1fr;
+  }
+
+  #btfw-theme-modal .modal-card-body{
+    padding: 22px 18px 26px;
+  }
 }
 
 /* Ensure videowrap doesn't collapse during load */

--- a/css/navbar.css
+++ b/css/navbar.css
@@ -1,138 +1,246 @@
 /* ======================================================================
    BillTube Framework — navbar.css
-   Elevated navbar styling aligned with theme tint + accent system
+   Fixed / tint-aware navbar that stays independent from CyTube base skins
    ====================================================================== */
 
-/* Keep content offset below the floating navbar */
-#btfw-grid {
-  margin-top: var(--btfw-top);
-}
-
-nav.navbar,
-.navbar,
-#navbar,
-.navbar-fixed-top {
-  position: fixed !important;
-  top: 12px;
-  left: 16px;
-  right: 16px;
-  z-index: 5200;
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  min-height: var(--btfw-navbar-height);
-  padding: 10px 18px;
-  background: var(--btfw-navbar-gradient);
-  border: 1px solid var(--btfw-navbar-border);
-  border-radius: 18px;
-  box-shadow: var(--btfw-navbar-shadow);
-  backdrop-filter: blur(18px);
-  -webkit-backdrop-filter: blur(18px);
-  box-sizing: border-box;
-}
-
-.navbar .navbar-header,
-.navbar .navbar-collapse {
-  background: transparent;
+#btfw-navhost > nav.navbar,
+#btfw-navhost > .navbar,
+#btfw-navhost > #navbar,
+#btfw-navhost > .navbar-fixed-top {
+  position: sticky !important;
+  top: 0;
+  left: 0;
+  right: 0;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  border-radius: 0 !important;
   border: 0;
-}
-
-.navbar .navbar-header {
+  border-bottom: 1px solid var(--btfw-navbar-divider, color-mix(in srgb, var(--btfw-border) 86%, transparent 14%));
+  background:
+    linear-gradient(180deg,
+      color-mix(in srgb, var(--btfw-color-bg) 76%, transparent 24%),
+      color-mix(in srgb, var(--btfw-color-surface) 88%, transparent 12%));
+  background-image: none !important;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 12px 28px color-mix(in srgb, var(--btfw-color-bg) 58%, transparent 42%);
   display: flex;
   align-items: center;
-  gap: 12px;
+  min-height: var(--btfw-navbar-height);
+  box-sizing: border-box;
+  z-index: 5400;
+  isolation: isolate;
 }
 
-.navbar .navbar-brand {
-  color: var(--btfw-navbar-link);
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  font-size: 1.05rem;
-  text-transform: none;
+#btfw-navhost > nav.navbar .container,
+#btfw-navhost > .navbar .container {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: clamp(12px, 2vw, 28px);
+  padding: 0 clamp(18px, 3vw, 36px);
+  margin: 0;
+}
+
+#btfw-navhost .navbar-header,
+#btfw-navhost .navbar-collapse,
+#btfw-navhost #nav-collapsible {
+  background: transparent !important;
+  border: 0 !important;
+  box-shadow: none !important;
+}
+
+#btfw-navhost .navbar-header {
+  display: flex;
+  align-items: center;
+  gap: clamp(10px, 1.6vw, 22px);
+  margin-right: auto;
+  min-height: var(--btfw-navbar-height);
+}
+
+#btfw-navhost .navbar-brand {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
+  font-size: clamp(1.05rem, 1.7vw, 1.2rem);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--btfw-navbar-link);
+  text-decoration: none;
+  text-transform: none;
+  padding: 0;
 }
 
-.navbar .navbar-brand:hover,
-.navbar .navbar-brand:focus {
+#btfw-navhost .navbar-brand:hover,
+#btfw-navhost .navbar-brand:focus {
   color: var(--btfw-navbar-link-hover);
   text-decoration: none;
 }
 
-.navbar .navbar-toggle {
-  border-radius: 14px;
-  border: 1px solid color-mix(in srgb, var(--btfw-color-accent) 34%, transparent 66%);
+#btfw-navhost .navbar-toggle,
+#btfw-navhost .navbar-toggler {
+  border-radius: 8px;
+  border: 1px solid color-mix(in srgb, var(--btfw-color-accent) 30%, transparent 70%);
   background: color-mix(in srgb, var(--btfw-color-panel) 92%, transparent 8%);
   color: var(--btfw-navbar-link);
   padding: 6px 12px;
-  transition: filter 0.18s ease;
+  transition: filter 0.18s ease, background 0.18s ease;
 }
 
-.navbar .navbar-toggle .icon-bar {
+#btfw-navhost .navbar-toggle .icon-bar {
   background-color: var(--btfw-navbar-link);
-  transition: background 0.18s ease;
 }
 
-.navbar .navbar-toggle:hover,
-.navbar .navbar-toggle:focus {
+#btfw-navhost .navbar-toggle:hover,
+#btfw-navhost .navbar-toggle:focus,
+#btfw-navhost .navbar-toggler:hover,
+#btfw-navhost .navbar-toggler:focus {
   filter: brightness(1.1);
 }
 
-.navbar .nav,
-.navbar .navbar-nav {
+#btfw-navhost .navbar-nav,
+#btfw-navhost .nav {
   display: flex;
   align-items: center;
   gap: 6px;
   margin: 0;
+  padding: 0;
+  float: none !important;
 }
 
-.navbar .nav > li,
-.navbar .navbar-nav > li {
+#btfw-navhost .navbar-nav > li,
+#btfw-navhost .nav > li {
   display: flex;
   align-items: center;
 }
 
-.navbar .nav > li > a,
-.navbar .navbar-nav > li > a {
+#btfw-navhost .navbar-nav > li > a,
+#btfw-navhost .nav > li > a {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  padding: 8px 14px;
-  border-radius: 12px;
+  padding: 10px 14px;
+  border-radius: 8px;
+  background: transparent;
   color: var(--btfw-navbar-link);
   font-weight: 600;
   letter-spacing: 0.01em;
   transition: background 0.18s ease, color 0.18s ease, box-shadow 0.18s ease;
+  text-decoration: none;
 }
 
-.navbar .nav > li > a .fa,
-.navbar .navbar-nav > li > a .glyphicon {
+#btfw-navhost .navbar-nav > li > a .fa,
+#btfw-navhost .nav > li > a .fa,
+#btfw-navhost .navbar-nav > li > a .glyphicon {
   font-size: 0.95em;
   opacity: 0.8;
 }
 
-.navbar .nav > li > a:hover,
-.navbar .nav > li > a:focus,
-.navbar .nav > li.open > a,
-.navbar .navbar-nav > li > a:hover,
-.navbar .navbar-nav > li > a:focus,
-.navbar .navbar-nav > li.open > a {
+#btfw-navhost .navbar-nav > li > a:hover,
+#btfw-navhost .navbar-nav > li > a:focus,
+#btfw-navhost .navbar-nav > li.open > a,
+#btfw-navhost .nav > li > a:hover,
+#btfw-navhost .nav > li > a:focus,
+#btfw-navhost .nav > li.open > a {
   background: color-mix(in srgb, var(--btfw-color-accent) 26%, transparent 74%);
   color: var(--btfw-navbar-link-hover);
-  box-shadow: 0 10px 20px color-mix(in srgb, var(--btfw-color-accent) 18%, transparent 82%);
+  box-shadow: 0 10px 20px color-mix(in srgb, var(--btfw-color-accent) 16%, transparent 84%);
 }
 
-.navbar .dropdown-menu {
+#btfw-navhost .dropdown-menu {
   background: color-mix(in srgb, var(--btfw-color-panel) 94%, transparent 6%);
-  border: 1px solid color-mix(in srgb, var(--btfw-color-accent) 32%, transparent 68%);
-  border-radius: 16px;
-  box-shadow: 0 20px 36px color-mix(in srgb, var(--btfw-color-bg) 55%, transparent 45%);
+  border: 1px solid color-mix(in srgb, var(--btfw-color-accent) 28%, transparent 72%);
+  border-radius: 14px;
+  box-shadow: 0 20px 40px color-mix(in srgb, var(--btfw-color-bg) 55%, transparent 45%);
   padding: 10px 0;
   min-width: 210px;
 }
 
-.navbar .dropdown-menu > li > a {
+#btfw-navhost #nav-collapsible,
+#btfw-navhost .navbar-collapse {
+  margin-left: auto;
+  padding: 0;
+  flex: 0 1 auto;
+  background: transparent !important;
+}
+
+#btfw-navhost .navbar-right { margin-left: auto !important; }
+
+#btfw-navhost .navbar-form { margin: 0; }
+
+@media (min-width: 769px) {
+  #btfw-navhost #nav-collapsible,
+  #btfw-navhost .navbar-collapse {
+    display: flex !important;
+    align-items: center;
+    justify-content: flex-end;
+    gap: clamp(10px, 1.2vw, 18px);
+  }
+
+  #btfw-navhost #nav-collapsible > ul,
+  #btfw-navhost .navbar-collapse > ul {
+    display: flex;
+    align-items: center;
+    gap: clamp(4px, 0.8vw, 12px);
+    margin: 0;
+  }
+}
+
+@media (max-width: 980px) {
+  #btfw-navhost > nav.navbar,
+  #btfw-navhost > .navbar,
+  #btfw-navhost > #navbar,
+  #btfw-navhost > .navbar-fixed-top {
+    min-height: 56px;
+  }
+
+  #btfw-navhost > nav.navbar .container,
+  #btfw-navhost > .navbar .container {
+    padding: 0 clamp(16px, 3vw, 24px);
+  }
+
+  #btfw-navhost #nav-collapsible,
+  #btfw-navhost .navbar-collapse {
+    position: static !important;
+    width: 100%;
+    margin: 0;
+    padding: 12px 0;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+
+  #btfw-navhost #nav-collapsible.in,
+  #btfw-navhost .navbar-collapse.in,
+  #btfw-navhost #nav-collapsible.show,
+  #btfw-navhost .navbar-collapse.show,
+  #btfw-navhost #nav-collapsible.collapsing,
+  #btfw-navhost .navbar-collapse.collapsing {
+    display: flex !important;
+  }
+
+  #btfw-navhost #nav-collapsible > ul,
+  #btfw-navhost .navbar-collapse > ul {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 6px;
+  }
+
+  #btfw-navhost .navbar-nav > li,
+  #btfw-navhost .nav > li {
+    width: 100%;
+  }
+
+  #btfw-navhost .navbar-nav > li > a,
+  #btfw-navhost .nav > li > a {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+
+#btfw-navhost .dropdown-menu > li > a {
   color: var(--btfw-navbar-link-soft);
   font-weight: 500;
   padding: 10px 18px;
@@ -140,19 +248,36 @@ nav.navbar,
   margin: 0 8px;
 }
 
-.navbar .dropdown-menu > li > a:hover,
-.navbar .dropdown-menu > li.active > a,
-.navbar .dropdown-menu > li > a:focus {
+#btfw-navhost .dropdown-menu > li > a:hover,
+#btfw-navhost .dropdown-menu > li.active > a,
+#btfw-navhost .dropdown-menu > li > a:focus {
   background: color-mix(in srgb, var(--btfw-color-accent) 22%, transparent 78%);
   color: var(--btfw-navbar-link-hover);
 }
 
-.navbar .dropdown-menu .divider {
+#btfw-navhost .dropdown-menu .divider {
   background-color: color-mix(in srgb, var(--btfw-color-accent) 24%, transparent 76%);
 }
 
+#btfw-navhost #nav-collapsible,
+#btfw-navhost .navbar-collapse {
+  margin-left: auto !important;
+  display: flex !important;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 6px;
+}
+
+#btfw-navhost #nav-collapsible > ul,
+#btfw-navhost .navbar-collapse > ul {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+}
+
 #btfw-theme-btn-nav,
-.navbar .nav > li > a#btfw-theme-btn-nav {
+#btfw-navhost #btfw-theme-btn-nav {
   background: var(--btfw-navbar-pill-bg);
   color: var(--btfw-navbar-pill-text) !important;
   border: 0;
@@ -196,6 +321,36 @@ nav.navbar,
   object-fit: cover;
   border: 2px solid color-mix(in srgb, var(--btfw-color-accent) 34%, transparent 66%);
   box-shadow: 0 6px 14px color-mix(in srgb, var(--btfw-color-bg) 40%, transparent 60%);
+}
+
+@media (max-width: 900px) {
+  #btfw-navhost > nav.navbar,
+  #btfw-navhost > .navbar,
+  #btfw-navhost > #navbar,
+  #btfw-navhost > .navbar-fixed-top {
+    padding: 10px clamp(12px, 3vw, 20px);
+    flex-wrap: wrap;
+  }
+
+  #btfw-navhost .navbar-header {
+    width: 100%;
+    justify-content: space-between;
+    margin-right: 0;
+  }
+
+  #btfw-navhost #nav-collapsible,
+  #btfw-navhost .navbar-collapse {
+    width: 100%;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    margin-top: 8px !important;
+  }
+
+  #btfw-navhost #nav-collapsible > ul,
+  #btfw-navhost .navbar-collapse > ul {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
 }
 
 /* Collapsed menu (mobile) */

--- a/css/tokens.css
+++ b/css/tokens.css
@@ -1,11 +1,11 @@
 :root {
   --btfw-top: 64px;
   --btfw-gap: 10px;
-  --btfw-color-bg: var(--btfw-theme-bg, #0f1524);
-  --btfw-color-surface: var(--btfw-theme-surface, #151d30);
-  --btfw-color-panel: var(--btfw-theme-panel, #1d2640);
-  --btfw-color-text: var(--btfw-theme-text, #e6edf3);
-  --btfw-color-chat-text: var(--btfw-theme-chat-text, var(--btfw-color-text));
+  --btfw-color-bg: var(--btfw-theme-bg, #05060d);
+  --btfw-color-surface: var(--btfw-theme-surface, #0b101c);
+  --btfw-color-panel: var(--btfw-theme-panel, #121b2f);
+  --btfw-color-text: var(--btfw-theme-text, #e6edf5);
+  --btfw-color-chat-text: var(--btfw-theme-chat-text, #d9e3ff);
   --btfw-color-accent: var(--btfw-theme-accent, #6d4df6);
   --btfw-color-on-accent: color-mix(in srgb, var(--btfw-color-text) 94%, white 6%);
   --btfw-color-text-soft: color-mix(in srgb, var(--btfw-color-text) 82%, transparent 18%);
@@ -38,6 +38,7 @@
       color-mix(in srgb, var(--btfw-color-panel) 92%, transparent 8%),
       color-mix(in srgb, var(--btfw-color-accent) 22%, transparent 78%));
   --btfw-navbar-border: color-mix(in srgb, var(--btfw-color-accent) 26%, transparent 74%);
+  --btfw-navbar-divider: color-mix(in srgb, var(--btfw-color-panel) 60%, transparent 40%);
   --btfw-navbar-shadow: 0 18px 42px color-mix(in srgb, var(--btfw-color-bg) 52%, transparent 48%),
     0 6px 12px color-mix(in srgb, var(--btfw-color-bg) 40%, transparent 60%);
   --btfw-navbar-link: color-mix(in srgb, var(--btfw-color-text) 94%, transparent 6%);

--- a/modules/feature-bulma-layer.js
+++ b/modules/feature-bulma-layer.js
@@ -19,14 +19,22 @@ BTFW.define("feature:bulma-layer", [], async () => {
   const DARK_CSS = `
 /* --- Global dark scope --- */
 html[data-btfw-theme="dark"] { color-scheme: dark; }
-html[data-btfw-theme="dark"], html[data-btfw-theme="dark"] body { background:#0f131a; color:#e6edf3; }
+html[data-btfw-theme="dark"], html[data-btfw-theme="dark"] body {
+  background: var(--btfw-color-bg);
+  color: var(--btfw-color-text);
+}
+html[data-btfw-theme="dark"] body {
+  background-image: none;
+}
 
 /* Text/surfaces (Bulma) */
 html[data-btfw-theme="dark"] .content,
 html[data-btfw-theme="dark"] .title,
 html[data-btfw-theme="dark"] .subtitle,
 html[data-btfw-theme="dark"] p,
-html[data-btfw-theme="dark"] small { color:#e6edf3; }
+html[data-btfw-theme="dark"] small {
+  color: var(--btfw-color-text);
+}
 
 html[data-btfw-theme="dark"] .box,
 html[data-btfw-theme="dark"] .card,
@@ -35,65 +43,81 @@ html[data-btfw-theme="dark"] .menu,
 html[data-btfw-theme="dark"] .notification,
 html[data-btfw-theme="dark"] .dropdown-content,
 html[data-btfw-theme="dark"] .modal-card {
-  background:#141a22 !important;
-  color:#e6edf3 !important;
-  border:1px solid #253142 !important;
-  box-shadow: 0 12px 38px rgba(0,0,0,.6);
+  background: color-mix(in srgb, var(--btfw-color-surface) 92%, transparent 8%) !important;
+  color: var(--btfw-color-text) !important;
+  border: 1px solid var(--btfw-border) !important;
+  box-shadow: 0 18px 42px color-mix(in srgb, var(--btfw-color-bg) 55%, transparent 45%);
 }
 
 html[data-btfw-theme="dark"] .tabs.is-boxed li a { background:transparent; border-color:transparent; color:#c8d4e0; }
-html[data-btfw-theme="dark"] .tabs.is-boxed li.is-active a { background:#0f1620; color:#fff; border-color:#253142; }
+html[data-btfw-theme="dark"] .tabs.is-boxed li.is-active a {
+  background: color-mix(in srgb, var(--btfw-color-panel) 82%, transparent 18%);
+  color: var(--btfw-color-text);
+  border-color: var(--btfw-border);
+}
 
 /* Inputs */
 html[data-btfw-theme="dark"] .input,
 html[data-btfw-theme="dark"] .textarea,
 html[data-btfw-theme="dark"] .select select {
-  background:#0f1620 !important;
-  color:#e6edf3 !important;
-  border-color:#2b3a4a !important;
+  background: color-mix(in srgb, var(--btfw-color-panel) 94%, transparent 6%) !important;
+  color: var(--btfw-color-text) !important;
+  border-color: color-mix(in srgb, var(--btfw-border) 80%, transparent 20%) !important;
 }
 html[data-btfw-theme="dark"] .input::placeholder,
-html[data-btfw-theme="dark"] .textarea::placeholder { color:#9fb0c2 !important; }
+html[data-btfw-theme="dark"] .textarea::placeholder {
+  color: color-mix(in srgb, var(--btfw-color-text) 55%, transparent 45%) !important;
+}
 
 /* Buttons */
-html[data-btfw-theme="dark"] .button {
-  background:#1a2230; color:#e6edf3; border:1px solid rgba(255,255,255,.10);
+html[data-btfw-theme="dark"] .button,
+html[data-btfw-theme="dark"] .btn {
+  background: color-mix(in srgb, var(--btfw-color-panel) 88%, transparent 12%);
+  color: var(--btfw-color-text);
+  border: 1px solid color-mix(in srgb, var(--btfw-border) 70%, transparent 30%);
 }
-html[data-btfw-theme="dark"] .button:hover { filter:brightness(1.08); }
+html[data-btfw-theme="dark"] .button:hover,
+html[data-btfw-theme="dark"] .btn:hover {
+  filter: brightness(1.05);
+}
 html[data-btfw-theme="dark"] .button.is-link,
 html[data-btfw-theme="dark"] .button.is-primary {
-  background:#2563eb !important; border-color:#2159d3 !important; color:#fff !important;
+  background: color-mix(in srgb, var(--btfw-color-accent) 82%, transparent 18%) !important;
+  border-color: color-mix(in srgb, var(--btfw-color-accent) 68%, transparent 32%) !important;
+  color: var(--btfw-color-on-accent) !important;
 }
 
 /* Chat/stack surfaces you themed */
-html[data-btfw-theme="dark"] #main,
-html[data-btfw-theme="dark"] .container-fluid,
-html[data-btfw-theme="dark"] .well,
-html[data-btfw-theme="dark"] .btfw-stack,
-html[data-btfw-theme="dark"] .btfw-topbar { background:#0f131a; color:#e6edf3; }
 html[data-btfw-theme="dark"] #chatwrap,
 html[data-btfw-theme="dark"] #messagebuffer { background:transparent; }
 
 /* --- Bulma modal dark --- */
 html[data-btfw-theme="dark"] .modal { z-index: 6000 !important; }
-html[data-btfw-theme="dark"] .modal .modal-background { background-color: rgba(8,10,14,.8) !important; }
+html[data-btfw-theme="dark"] .modal .modal-background { background-color: color-mix(in srgb, var(--btfw-color-bg) 88%, transparent 12%) !important; }
 html[data-btfw-theme="dark"] .modal-card-head,
 html[data-btfw-theme="dark"] .modal-card-foot {
-  background-color:#0f1620 !important; border-color:#253142 !important; color:#e6edf3 !important;
+  background-color: color-mix(in srgb, var(--btfw-color-panel) 92%, transparent 8%) !important;
+  border-color: var(--btfw-border) !important;
+  color: var(--btfw-color-text) !important;
 }
-html[data-btfw-theme="dark"] .modal-card { background-color:#141a22 !important; color:#e6edf3 !important; }
-html[data-btfw-theme="dark"] .modal-card-title { color:#e6edf3 !important; }
+html[data-btfw-theme="dark"] .modal-card {
+  background-color: color-mix(in srgb, var(--btfw-color-surface) 94%, transparent 6%) !important;
+  color: var(--btfw-color-text) !important;
+}
+html[data-btfw-theme="dark"] .modal-card-title { color: var(--btfw-color-text) !important; }
 
 /* --- Bootstrap/CyTube modal bridge (skin Bootstrap modals to match Bulma dark) --- */
 html[data-btfw-theme="dark"] .modal.fade,
 html[data-btfw-theme="dark"] .modal.in,
 html[data-btfw-theme="dark"] .modal { z-index: 6000 !important; }
 html[data-btfw-theme="dark"] .modal-backdrop {
-  background-color: rgba(8,10,14,.8) !important; z-index: 0 !important;
+  background-color: color-mix(in srgb, var(--btfw-color-bg) 88%, transparent 12%) !important; z-index: 0 !important;
 }
 html[data-btfw-theme="dark"] .modal-dialog { max-width: 880px; }
 html[data-btfw-theme="dark"] .modal-content {
-  background-color:#141a22 !important; color:#e6edf3 !important; border:1px solid #253142 !important;
+  background-color: color-mix(in srgb, var(--btfw-color-surface) 94%, transparent 6%) !important;
+  color: var(--btfw-color-text) !important;
+  border:1px solid var(--btfw-border) !important;
 }
 @media screen and (min-width: 769px) {
     .modal-card, .modal-content {
@@ -102,14 +126,20 @@ html[data-btfw-theme="dark"] .modal-content {
 }
 html[data-btfw-theme="dark"] .modal-header,
 html[data-btfw-theme="dark"] .modal-footer {
-  background-color:#0f1620 !important; border-color:#253142 !important; color:#e6edf3 !important;
+  background-color: color-mix(in srgb, var(--btfw-color-panel) 92%, transparent 8%) !important;
+  border-color: var(--btfw-border) !important;
+  color: var(--btfw-color-text) !important;
 }
-html[data-btfw-theme="dark"] .modal-title { color:#e6edf3 !important; }
+html[data-btfw-theme="dark"] .modal-title { color: var(--btfw-color-text) !important; }
 html[data-btfw-theme="dark"] .modal .btn-primary {
-  background:#2563eb !important; border-color:#2159d3 !important; color:#fff !important;
+  background: color-mix(in srgb, var(--btfw-color-accent) 82%, transparent 18%) !important;
+  border-color: color-mix(in srgb, var(--btfw-color-accent) 68%, transparent 32%) !important;
+  color: var(--btfw-color-on-accent) !important;
 }
 html[data-btfw-theme="dark"] .modal .btn-default {
-  background:#1c2530 !important; border-color:#2b3a4a !important; color:#e6edf3 !important;
+  background: color-mix(in srgb, var(--btfw-color-panel) 88%, transparent 12%) !important;
+  border-color: color-mix(in srgb, var(--btfw-border) 70%, transparent 30%) !important;
+  color: var(--btfw-color-text) !important;
 }
 /* Scroll lock (Bootstrap) */
 body.modal-open { overflow: hidden; }

--- a/modules/feature-channel-theme-admin.js
+++ b/modules/feature-channel-theme-admin.js
@@ -28,14 +28,14 @@ BTFW.define("feature:channelThemeAdmin", [], async () => {
   ];
 
   const DEFAULT_CONFIG = {
-    version: 3,
+    version: 4,
     tint: "midnight",
     colors: {
-      background: "#0f1524",
-      surface: "#151d30",
-      panel: "#1d2640",
-      text: "#e8ecf8",
-      chatText: "#d4dcff",
+      background: "#05060d",
+      surface: "#0b111d",
+      panel: "#141f36",
+      text: "#e8ecfb",
+      chatText: "#d4defd",
       accent: "#6d4df6"
     },
     slider: {
@@ -45,6 +45,11 @@ BTFW.define("feature:channelThemeAdmin", [], async () => {
     typography: {
       preset: "inter",
       customFamily: ""
+    },
+    integrations: {
+      tmdb: {
+        apiKey: ""
+      }
     },
     resources: {
       scripts: [],
@@ -60,44 +65,44 @@ BTFW.define("feature:channelThemeAdmin", [], async () => {
     midnight: {
       name: "Midnight Pulse",
       colors: {
-        background: "#0f1524",
-        surface: "#151d30",
-        panel: "#1d2640",
-        text: "#e8ecf8",
-        chatText: "#d4dcff",
+        background: "#05060d",
+        surface: "#0b111d",
+        panel: "#141f36",
+        text: "#e8ecfb",
+        chatText: "#d4defd",
         accent: "#6d4df6"
       }
     },
     aurora: {
       name: "Aurora Bloom",
       colors: {
-        background: "#081c26",
-        surface: "#0e2532",
-        panel: "#143144",
-        text: "#f2fbff",
-        chatText: "#daf3ff",
+        background: "#02121c",
+        surface: "#071b28",
+        panel: "#10273b",
+        text: "#e9fbff",
+        chatText: "#d0ebff",
         accent: "#4dd0f6"
       }
     },
     sunset: {
       name: "Sunset Neon",
       colors: {
-        background: "#1c0b16",
-        surface: "#28101f",
-        panel: "#331728",
-        text: "#ffeef8",
-        chatText: "#ffd1e5",
+        background: "#13030c",
+        surface: "#1b0813",
+        panel: "#26101d",
+        text: "#ffe7f1",
+        chatText: "#ffcade",
         accent: "#ff6b9d"
       }
     },
     ember: {
       name: "Ember Forge",
       colors: {
-        background: "#1b1309",
-        surface: "#241a0d",
-        panel: "#2e210f",
-        text: "#fcead6",
-        chatText: "#f7d3a8",
+        background: "#110802",
+        surface: "#190d05",
+        panel: "#24140a",
+        text: "#fbe3c9",
+        chatText: "#f6cea3",
         accent: "#ff914d"
       }
     }
@@ -157,6 +162,7 @@ BTFW.define("feature:channelThemeAdmin", [], async () => {
   };
   const FONT_DEFAULT_ID = "inter";
   const FONT_FALLBACK_FAMILY = FONT_PRESETS[FONT_DEFAULT_ID].family;
+  const THEME_FONT_LINK_ID = "btfw-theme-font";
 
   const STYLE_ID = "btfw-theme-admin-style";
 
@@ -268,6 +274,34 @@ BTFW.define("feature:channelThemeAdmin", [], async () => {
       family,
       url: url || ""
     };
+  }
+
+  function ensureStylesheetLink(id, url){
+    if (!document.head) return;
+    let link = document.getElementById(id);
+    if (url) {
+      if (!link) {
+        link = document.createElement("link");
+        link.id = id;
+        link.rel = "stylesheet";
+        document.head.appendChild(link);
+      }
+      if (link.getAttribute("href") !== url) {
+        link.setAttribute("href", url);
+      }
+    } else if (link && link.parentElement) {
+      link.parentElement.removeChild(link);
+    }
+  }
+
+  function applyLiveTypographyAssets(typography){
+    const resolved = resolveTypographyConfig(typography);
+    const root = document.documentElement;
+    if (root && resolved.family) {
+      root.style.setProperty("--btfw-theme-font-family", resolved.family);
+    }
+    ensureStylesheetLink(THEME_FONT_LINK_ID, resolved.url || "");
+    return resolved;
   }
 
   function cloneDefaults(){
@@ -419,14 +453,29 @@ BTFW.define("feature:channelThemeAdmin", [], async () => {
       });
     }
   }
+  function applyIntegrations(integrations){
+    integrations = integrations || {};
+    cfg.integrations = cfg.integrations || {};
+    if (!cfg.integrations.tmdb || typeof cfg.integrations.tmdb !== 'object') {
+      cfg.integrations.tmdb = { apiKey: '' };
+    }
+    var tmdb = integrations.tmdb || cfg.integrations.tmdb || {};
+    var key = typeof tmdb.apiKey === 'string' ? tmdb.apiKey.trim() : '';
+    cfg.integrations.tmdb.apiKey = key;
+    window.BTFW_CONFIG = window.BTFW_CONFIG || {};
+    if (typeof window.BTFW_CONFIG.tmdb !== 'object') window.BTFW_CONFIG.tmdb = {};
+    window.BTFW_CONFIG.tmdb.apiKey = key;
+    window.BTFW_CONFIG.tmdbKey = key;
+    try { if (document.body) document.body.dataset.tmdbKey = key; } catch (_) {}
+  }
   function applyColors(colors){
     colors = colors || {};
     var root = document.documentElement;
     if (!root) return;
-    var bg = colors.background || '#0f1524';
-    var surface = colors.surface || colors.panel || '#151d30';
-    var panel = colors.panel || '#1d2640';
-    var text = colors.text || '#e8ecf8';
+    var bg = colors.background || '#05060d';
+    var surface = colors.surface || colors.panel || '#0b111d';
+    var panel = colors.panel || '#141f36';
+    var text = colors.text || '#e8ecfb';
     var chatText = colors.chatText || text;
     var accent = colors.accent || '#6d4df6';
     cfg.colors = cfg.colors || {};
@@ -494,6 +543,7 @@ BTFW.define("feature:channelThemeAdmin", [], async () => {
   applySlider(cfg.slider || {});
   applyBranding(cfg.branding || {});
   applyColors(cfg.colors || {});
+  applyIntegrations(cfg.integrations || {});
   applyTypography(cfg.typography || {});
 })(window.BTFW_THEME_ADMIN);\n${JS_BLOCK_END}`;
 
@@ -501,11 +551,11 @@ BTFW.define("feature:channelThemeAdmin", [], async () => {
 
   function buildCssBlock(cfg){
     const colors = cfg.colors || {};
-    const typography = resolveTypographyConfig(cfg.typography || {});
-    const bg = colors.background || "#0f1524";
-    const surface = colors.surface || colors.panel || "#161f33";
-    const panel = colors.panel || "#1d2640";
-    const textColor = colors.text || "#f0f4ff";
+    const typography = applyLiveTypographyAssets(cfg.typography || {});
+    const bg = colors.background || "#05060d";
+    const surface = colors.surface || colors.panel || "#0b111d";
+    const panel = colors.panel || "#141f36";
+    const textColor = colors.text || "#e8ecfb";
     const chatText = colors.chatText || textColor;
     const accent = colors.accent || "#6d4df6";
     const fontFamily = typography.family || FONT_FALLBACK_FAMILY;
@@ -561,12 +611,12 @@ BTFW.define("feature:channelThemeAdmin", [], async () => {
     const preview = panel.querySelector(".preview");
     if (!preview) return;
     const colors = cfg.colors || {};
-    const typography = resolveTypographyConfig(cfg.typography || {});
-    preview.style.setProperty("--bg", colors.background || "#0f1524");
-    preview.style.setProperty("--surface", colors.surface || colors.panel || "#161f33");
-    preview.style.setProperty("--panel", colors.panel || "#1d2640");
+    const typography = applyLiveTypographyAssets(cfg.typography || {});
+    preview.style.setProperty("--bg", colors.background || "#05060d");
+    preview.style.setProperty("--surface", colors.surface || colors.panel || "#0b111d");
+    preview.style.setProperty("--panel", colors.panel || "#141f36");
     preview.style.setProperty("--accent", colors.accent || "#6d4df6");
-    preview.style.background = `linear-gradient(160deg, ${colors.background || "#0f1524"}, ${colors.surface || colors.panel || "#161f33"})`;
+    preview.style.background = `linear-gradient(160deg, ${colors.background || "#05060d"}, ${colors.surface || colors.panel || "#0b111d"})`;
     const accent = panel.querySelector(".preview__accent");
     if (accent) {
       accent.style.background = colors.accent || "#6d4df6";
@@ -680,6 +730,13 @@ BTFW.define("feature:channelThemeAdmin", [], async () => {
     }
     updated.sliderEnabled = Boolean(updated.slider?.enabled);
     updated.sliderJson = updated.slider?.feedUrl || "";
+    if (!updated.integrations || typeof updated.integrations !== "object") {
+      updated.integrations = cloneDefaults().integrations;
+    }
+    if (!updated.integrations.tmdb || typeof updated.integrations.tmdb !== "object") {
+      updated.integrations.tmdb = { apiKey: "" };
+    }
+    updated.integrations.tmdb.apiKey = (updated.integrations.tmdb.apiKey || "").trim();
     if (!updated.typography || typeof updated.typography !== "object") {
       updated.typography = cloneDefaults().typography;
     }

--- a/modules/feature-channels.js
+++ b/modules/feature-channels.js
@@ -132,17 +132,17 @@ BTFW.define("feature:channels", [], async () => {
         border-radius: 16px;
         border: 1px solid rgba(109, 77, 246, 0.22);
         border: 1px solid color-mix(in srgb, var(--btfw-theme-accent, #6d4df6) 28%, transparent 72%);
-        background: rgba(20, 28, 42, 0.92);
+        background: rgba(12, 18, 34, 0.92);
         background: linear-gradient(135deg,
-          color-mix(in srgb, var(--btfw-theme-surface, #151d30) 94%, transparent 6%),
-          color-mix(in srgb, var(--btfw-theme-panel, #1d2640) 86%, black 14%));
+          color-mix(in srgb, var(--btfw-theme-surface, #0b111d) 94%, transparent 6%),
+          color-mix(in srgb, var(--btfw-theme-panel, #141f36) 86%, black 14%));
         padding: 18px 52px;
         display: flex;
         align-items: center;
         gap: 14px;
         width: 100%;
-        color: var(--btfw-theme-text, #e6edf3);
-        box-shadow: 0 24px 48px color-mix(in srgb, var(--btfw-theme-bg, #0f1524) 30%, transparent 70%);
+        color: var(--btfw-theme-text, #e8ecfb);
+        box-shadow: 0 24px 48px color-mix(in srgb, var(--btfw-theme-bg, #05060d) 30%, transparent 70%);
         backdrop-filter: blur(14px);
       }
 
@@ -168,12 +168,12 @@ BTFW.define("feature:channels", [], async () => {
         flex-direction: column;
         gap: 8px;
         text-decoration: none;
-        color: color-mix(in srgb, var(--btfw-theme-text, #e6edf3) 96%, transparent 4%);
-        background: color-mix(in srgb, var(--btfw-theme-surface, #151d30) 88%, transparent 12%);
+        color: color-mix(in srgb, var(--btfw-theme-text, #e8ecfb) 96%, transparent 4%);
+        background: color-mix(in srgb, var(--btfw-theme-surface, #0b111d) 88%, transparent 12%);
         border-radius: 12px;
         border: 1px solid color-mix(in srgb, var(--btfw-theme-accent, #6d4df6) 22%, transparent 78%);
         overflow: hidden;
-        box-shadow: 0 14px 30px color-mix(in srgb, var(--btfw-theme-panel, #1d2640) 28%, transparent 72%);
+        box-shadow: 0 14px 30px color-mix(in srgb, var(--btfw-theme-panel, #141f36) 28%, transparent 72%);
         transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease, background 0.18s ease;
         cursor: grab;
         user-select: none;
@@ -183,7 +183,7 @@ BTFW.define("feature:channels", [], async () => {
       .btfw-channels__link:focus {
         transform: translateY(-4px);
         border-color: color-mix(in srgb, var(--btfw-theme-accent, #6d4df6) 70%, white 30%);
-        background: color-mix(in srgb, var(--btfw-theme-panel, #1d2640) 82%, var(--btfw-theme-accent, #6d4df6) 18%);
+        background: color-mix(in srgb, var(--btfw-theme-panel, #141f36) 82%, var(--btfw-theme-accent, #6d4df6) 18%);
         box-shadow: 0 18px 36px color-mix(in srgb, var(--btfw-theme-accent, #6d4df6) 35%, transparent 65%);
       }
 
@@ -191,7 +191,7 @@ BTFW.define("feature:channels", [], async () => {
         position: relative;
         aspect-ratio: 16 / 9;
         overflow: hidden;
-        background: color-mix(in srgb, var(--btfw-theme-panel, #1d2640) 88%, black 12%);
+        background: color-mix(in srgb, var(--btfw-theme-panel, #141f36) 88%, black 12%);
       }
 
       .btfw-channels__thumb {

--- a/modules/feature-chat-commands.js
+++ b/modules/feature-chat-commands.js
@@ -110,18 +110,23 @@ function getCurrentTitle(){
   // ---------- TMDB summary ----------
   function getTMDBKey(){
     try {
-      const k1 = (window.BTFW_CONFIG && typeof window.BTFW_CONFIG.tmdbKey === "string") ? window.BTFW_CONFIG.tmdbKey.trim() : "";
-      let   k2 = ""; try { k2 = (localStorage.getItem("btfw:tmdb:key") || "").trim(); } catch(_) {}
+      const cfg = (window.BTFW_CONFIG && typeof window.BTFW_CONFIG === "object") ? window.BTFW_CONFIG : {};
+      const tmdbObj = (cfg.tmdb && typeof cfg.tmdb === "object") ? cfg.tmdb : {};
+      const cfgKey = typeof tmdbObj.apiKey === "string" ? tmdbObj.apiKey.trim() : "";
+      const legacyCfg = typeof cfg.tmdbKey === "string" ? cfg.tmdbKey.trim() : "";
+      let lsKey = "";
+      try { lsKey = (localStorage.getItem("btfw:tmdb:key") || "").trim(); }
+      catch(_) {}
       const g  = v => (v==null ? "" : String(v)).trim();
-      const k3 = g(window.TMDB_API_KEY) || g(window.BTFW_TMDB_KEY) || g(window.tmdb_key);
-      const k4 = (document.body?.dataset?.tmdbKey || "").trim();
-      const key = k1 || k2 || k3 || k4;
+      const globalKey = g(window.TMDB_API_KEY) || g(window.BTFW_TMDB_KEY) || g(window.tmdb_key);
+      const bodyKey = (document.body?.dataset?.tmdbKey || "").trim();
+      const key = cfgKey || legacyCfg || lsKey || globalKey || bodyKey;
       return key || null;
     } catch(_) { return null; }
   }
   async function fetchTMDBSummary(title){
     const key = getTMDBKey();
-    if (!key) return 'TMDB key missing. Set one of:\nwindow.BTFW_CONFIG.tmdbKey = "KEY";\nlocalStorage.setItem("btfw:tmdb:key","KEY");\nwindow.tmdb_key = "KEY";';
+    if (!key) return 'TMDB key missing. Open Theme Settings → General → Integrations to add your TMDB API key, or set one of:\nwindow.BTFW_CONFIG.tmdb = { apiKey: "KEY" };\nlocalStorage.setItem("btfw:tmdb:key","KEY");\nwindow.tmdb_key = "KEY";';
     try {
       const q = encodeURIComponent(title);
       const url = `https://api.themoviedb.org/3/search/multi?api_key=${key}&query=${q}&include_adult=false&language=en-US`;

--- a/modules/feature-layout.js
+++ b/modules/feature-layout.js
@@ -2,6 +2,7 @@ BTFW.define("feature:layout", ["feature:styleCore","feature:bulma"], async ({}) 
   const SPLIT_KEY = "btfw:grid:leftPx";
   const CHAT_SIDE_KEY = "btfw:layout:chatSide";
   const MOBILE_STACK_ID = "btfw-mobile-stack";
+  const NAV_HOST_ID = "btfw-navhost";
   const VIDEO_MIN_PX = 520;
   const DEFAULT_VIDEO_TARGET = 680;
   const CHAT_MIN_PX = 360;
@@ -385,6 +386,8 @@ BTFW.define("feature:layout", ["feature:styleCore","feature:bulma"], async ({}) 
       const split=document.createElement("div");
       split.id="btfw-vsplit";
 
+      ensureNavHost(grid);
+
       grid.appendChild(left);
       grid.appendChild(split);
       grid.appendChild(right);
@@ -397,11 +400,14 @@ BTFW.define("feature:layout", ["feature:styleCore","feature:bulma"], async ({}) 
       const left=document.getElementById("btfw-leftpad");
       const right=document.getElementById("btfw-chatcol");
       const v=document.getElementById("videowrap");
-      const c=document.getElementById("chatwrap"); 
+      const c=document.getElementById("chatwrap");
       const q=document.getElementById("playlistrow")||document.getElementById("playlistwrap")||document.getElementById("queuecontainer");
-      
-      if(v && !left.contains(v)) left.appendChild(v); 
-      if(q && !left.contains(q)) left.appendChild(q); 
+      const grid=document.getElementById("btfw-grid");
+
+      ensureNavHost(grid);
+
+      if(v && !left.contains(v)) left.appendChild(v);
+      if(q && !left.contains(q)) left.appendChild(q);
       if(c && !right.contains(c)) right.appendChild(c);
     }
 
@@ -511,3 +517,36 @@ BTFW.define("feature:layout", ["feature:styleCore","feature:bulma"], async ({}) 
 
   return {name:"feature:layout"};
 });
+  function findNavbarElement(){
+    const selectors = [
+      "nav.navbar",
+      ".navbar-fixed-top",
+      "#navbar"
+    ];
+    for (const sel of selectors) {
+      const el = document.querySelector(sel);
+      if (el) return el;
+    }
+    return null;
+  }
+
+  function ensureNavHost(grid){
+    if (!grid) return;
+    const navEl = findNavbarElement();
+    if (!navEl) return;
+
+    let host = document.getElementById(NAV_HOST_ID);
+    if (!host) {
+      host = document.createElement("div");
+      host.id = NAV_HOST_ID;
+      host.className = "btfw-navhost";
+    }
+
+    if (navEl.parentElement !== host) {
+      host.appendChild(navEl);
+    }
+
+    if (host.parentElement !== grid) {
+      grid.insertBefore(host, grid.firstChild);
+    }
+  }

--- a/modules/feature-style-core.js
+++ b/modules/feature-style-core.js
@@ -50,7 +50,10 @@ BTFW.define("feature:styleCore", [], async () => {
       z.textContent = `
         /* Keep navbar on top */
         #nav-collapsible, .navbar, #navbar, .navbar-fixed-top {
-          position: fixed !important; top: 0; left: 0; right: 0;
+          position: sticky !important;
+          top: 0;
+          left: 0;
+          right: 0;
           z-index: 5000 !important;
         }
         /* Bulma modal layered correctly above content */

--- a/modules/feature-theme-settings.js
+++ b/modules/feature-theme-settings.js
@@ -93,13 +93,13 @@ BTFW.define("feature:themeSettings", [], async () => {
     m.className = "modal";
     m.innerHTML = `
       <div class="modal-background"></div>
-      <div class="modal-card" style="width:min(820px,92vw)">
+      <div class="modal-card btfw-theme-modal-card">
         <header class="modal-card-head">
           <p class="modal-card-title">Theme Settings</p>
           <button class="delete" aria-label="close"></button>
         </header>
         <section class="modal-card-body">
-          <div class="tabs is-boxed is-small" id="btfw-ts-tabs">
+          <div class="tabs btfw-ts-tabs is-small" id="btfw-ts-tabs">
             <ul>
               <li class="is-active" data-tab="general"><a>General</a></li>
               <li data-tab="chat"><a>Chat</a></li>
@@ -110,101 +110,133 @@ BTFW.define("feature:themeSettings", [], async () => {
           <div id="btfw-ts-panels">
             <!-- General -->
             <div class="btfw-ts-panel" data-tab="general" style="display:block;">
-              <div class="content">
-                <h4>Appearance</h4>
-                <div class="field">
-                  <label class="label">Theme mode</label>
-                  <div class="control">
-                    <label class="radio" style="margin-right:12px;">
-                      <input type="radio" name="btfw-theme-mode" value="auto"> Auto (match system)
-                    </label>
-                    <label class="radio" style="margin-right:12px;">
-                      <input type="radio" name="btfw-theme-mode" value="dark"> Dark
-                    </label>
-                    <label class="radio">
-                      <input type="radio" name="btfw-theme-mode" value="light"> Light
-                    </label>
+              <div class="btfw-ts-grid">
+                <section class="btfw-ts-card">
+                  <header class="btfw-ts-card__header">
+                    <h3>Appearance</h3>
+                    <p>Select how the interface adapts to your lighting preferences.</p>
+                  </header>
+                  <div class="btfw-ts-card__body">
+                    <div class="btfw-ts-control btfw-ts-control--radios">
+                      <label class="radio">
+                        <input type="radio" name="btfw-theme-mode" value="auto"> <span>Auto (match system)</span>
+                      </label>
+                      <label class="radio">
+                        <input type="radio" name="btfw-theme-mode" value="dark"> <span>Dark</span>
+                      </label>
+                      <label class="radio">
+                        <input type="radio" name="btfw-theme-mode" value="light"> <span>Light</span>
+                      </label>
+                    </div>
                   </div>
-                </div>
+                </section>
+
+                <section class="btfw-ts-card">
+                  <header class="btfw-ts-card__header">
+                    <h3>Integrations</h3>
+                    <p>Connect API keys used by chat tools and commands.</p>
+                  </header>
+                  <div class="btfw-ts-card__body">
+                    <label class="btfw-input">
+                      <span class="btfw-input__label">TMDB API key</span>
+                      <input type="text" id="btfw-tmdb-key" data-btfw-bind="integrations.tmdb.apiKey" placeholder="YOUR_TMDB_KEY">
+                    </label>
+                    <p class="btfw-help">Required for the <code>!summary</code> command. Request a key at <a href="https://www.themoviedb.org/settings/api" target="_blank" rel="noopener">themoviedb.org</a>.</p>
+                  </div>
+                </section>
               </div>
             </div>
 
             <!-- Chat -->
             <div class="btfw-ts-panel" data-tab="chat" style="display:none;">
-              <div class="content">
-                <h4>Chat</h4>
-
-                <div class="field">
-                  <label class="label">Avatar size</label>
-                  <div class="control">
-                    <label class="radio" style="margin-right:12px;"><input type="radio" name="btfw-avatars-mode" value="off"> Off</label>
-                    <label class="radio" style="margin-right:12px;"><input type="radio" name="btfw-avatars-mode" value="small"> Small</label>
-                    <label class="radio"><input type="radio" name="btfw-avatars-mode" value="big"> Big</label>
-                  </div>
-                </div>
-
-                <div class="field">
-                  <label class="label">Chat text size</label>
-                  <div class="control btfw-range-control">
-                    <input type="range" id="btfw-chat-textsize" min="10" max="20" step="1">
-                    <span class="btfw-range-value" id="btfw-chat-textsize-value">14px</span>
-                  </div>
-                  <p class="help">Adjusts the chat font between 10&nbsp;px and 20&nbsp;px.</p>
-                </div>
-
-                <div class="field">
-                  <label class="label">Emote & GIF size</label>
-                  <div class="control">
-                    <div class="select is-small">
-                      <select id="btfw-emote-size">
-                        <option value="small">Small (100×100)</option>
-                        <option value="medium">Medium (130×130)</option>
-                        <option value="big">Big (170×170)</option>
-                      </select>
+              <div class="btfw-ts-grid">
+                <section class="btfw-ts-card">
+                  <header class="btfw-ts-card__header">
+                    <h3>Avatars & text</h3>
+                    <p>Adjust density and readability for the chat column.</p>
+                  </header>
+                  <div class="btfw-ts-card__body">
+                    <div class="btfw-ts-control btfw-ts-control--radios">
+                      <span class="btfw-input__label">Avatar size</span>
+                      <label class="radio"><input type="radio" name="btfw-avatars-mode" value="off"> <span>Off</span></label>
+                      <label class="radio"><input type="radio" name="btfw-avatars-mode" value="small"> <span>Small</span></label>
+                      <label class="radio"><input type="radio" name="btfw-avatars-mode" value="big"> <span>Big</span></label>
+                    </div>
+                    <div class="btfw-ts-control">
+                      <span class="btfw-input__label">Chat text size</span>
+                      <div class="control btfw-range-control">
+                        <input type="range" id="btfw-chat-textsize" min="10" max="20" step="1">
+                        <span class="btfw-range-value" id="btfw-chat-textsize-value">14px</span>
+                      </div>
+                      <p class="btfw-help">Set chat typography anywhere between 10&nbsp;px and 20&nbsp;px.</p>
                     </div>
                   </div>
-                  <p class="help">Applies to images with <code>.channel-emote</code> and the GIF picker.</p>
-                </div>
+                </section>
 
-                <div class="field">
-                  <label class="checkbox">
-                    <input type="checkbox" id="btfw-gif-autoplay"> Autoplay GIFs in chat (otherwise play on hover)
-                  </label>
-                </div>
+                <section class="btfw-ts-card">
+                  <header class="btfw-ts-card__header">
+                    <h3>Media</h3>
+                    <p>Control sticker and GIF behaviour for the chat experience.</p>
+                  </header>
+                  <div class="btfw-ts-card__body">
+                    <div class="btfw-ts-control">
+                      <label class="btfw-input__label" for="btfw-emote-size">Emote & GIF size</label>
+                      <div class="select is-small">
+                        <select id="btfw-emote-size">
+                          <option value="small">Small (100×100)</option>
+                          <option value="medium">Medium (130×130)</option>
+                          <option value="big">Big (170×170)</option>
+                        </select>
+                      </div>
+                      <p class="btfw-help">Applies to elements with <code>.channel-emote</code> and the GIF picker.</p>
+                    </div>
+                    <label class="checkbox btfw-checkbox">
+                      <input type="checkbox" id="btfw-gif-autoplay"> <span>Autoplay GIFs in chat (otherwise play on hover)</span>
+                    </label>
+                  </div>
+                </section>
               </div>
             </div>
 
             <!-- Video -->
             <div class="btfw-ts-panel" data-tab="video" style="display:none;">
-              <div class="content">
-                <h4>Video</h4>
-                <div class="field">
-                  <label class="label">Desktop layout</label>
-                  <div class="control">
-                    <label class="radio" style="margin-right:12px;">
-                      <input type="radio" name="btfw-chat-side" value="right"> Video left, chat right
-                    </label>
-                    <label class="radio">
-                      <input type="radio" name="btfw-chat-side" value="left"> Chat left, video right
-                    </label>
+              <div class="btfw-ts-grid">
+                <section class="btfw-ts-card">
+                  <header class="btfw-ts-card__header">
+                    <h3>Layout</h3>
+                    <p>Choose how the desktop layout positions chat and video.</p>
+                  </header>
+                  <div class="btfw-ts-card__body">
+                    <div class="btfw-ts-control btfw-ts-control--radios">
+                      <label class="radio">
+                        <input type="radio" name="btfw-chat-side" value="right"> <span>Video left, chat right</span>
+                      </label>
+                      <label class="radio">
+                        <input type="radio" name="btfw-chat-side" value="left"> <span>Chat left, video right</span>
+                      </label>
+                    </div>
+                    <p class="btfw-help">Mobile screens automatically collapse into a stacked layout.</p>
                   </div>
-                  <p class="help">Mobile screens switch to a stacked view automatically.</p>
-                </div>
-                <div class="field">
-                  <label class="checkbox">
-                    <input type="checkbox" id="btfw-pip-toggle"> Picture-in-Picture (experimental)
-                  </label>
-                </div>
-                <label class="checkbox" style="display:block;margin-top:10px;">
-                  <input type="checkbox" id="btfw-billcast-toggle" checked>
-                  Enable Billcast (Chromecast sender)
-                </label>
-                <div class="field">
-                  <label class="checkbox">
-                    <input type="checkbox" id="btfw-localsubs-toggle"> Show “Local Subtitles” button
-                  </label>
-                  <p class="help">Load a local .vtt or .srt file into the HTML5 player.</p>
-                </div>
+                </section>
+
+                <section class="btfw-ts-card">
+                  <header class="btfw-ts-card__header">
+                    <h3>Playback tools</h3>
+                    <p>Toggle experimental features for the HTML5 player.</p>
+                  </header>
+                  <div class="btfw-ts-card__body">
+                    <label class="checkbox btfw-checkbox">
+                      <input type="checkbox" id="btfw-pip-toggle"> <span>Enable Picture-in-Picture controls</span>
+                    </label>
+                    <label class="checkbox btfw-checkbox">
+                      <input type="checkbox" id="btfw-billcast-toggle" checked> <span>Enable Billcast (Chromecast sender)</span>
+                    </label>
+                    <label class="checkbox btfw-checkbox">
+                      <input type="checkbox" id="btfw-localsubs-toggle"> <span>Show the “Local Subtitles” button</span>
+                    </label>
+                    <p class="btfw-help">Allows viewers to load local <code>.vtt</code> or <code>.srt</code> caption files.</p>
+                  </div>
+                </section>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- embed the navbar within #btfw-grid with new sticky styling and font overrides so CyTube base themes no longer bleed through
- overhaul the theme settings modal with a card layout, darker defaults, and an integrations section for the TMDB API key
- align dark-mode helpers, layout tokens, and channel previews with the refreshed tint palette

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5201a848c8329a1026878cb62d27b