### PR TITLE
Adjust layout defaults and Firefox compatibility fixes

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -132,7 +132,7 @@ a:hover {
 /* ---------- Main 2-column grid: left content + splitter + right chat ---------- */
 #btfw-grid{
   display: grid;
-  grid-template-columns: minmax(520px,1fr) var(--btfw-split-width) minmax(var(--btfw-chat-min),var(--btfw-chat-max));
+  grid-template-columns: minmax(520px,7fr) var(--btfw-split-width) minmax(var(--btfw-chat-min),3fr);
   grid-template-areas:
     "nav nav nav"
     "video split chat";
@@ -196,14 +196,14 @@ a:hover {
 
 /* Allow swapping chat/video positions on desktop */
 #btfw-grid.btfw-grid--chat-left{
-  grid-template-columns: minmax(var(--btfw-chat-min),var(--btfw-chat-max)) var(--btfw-split-width) minmax(520px,1fr);
+  grid-template-columns: minmax(var(--btfw-chat-min),3fr) var(--btfw-split-width) minmax(520px,7fr);
   grid-template-areas:
     "nav nav nav"
     "chat split video";
 }
 
 #btfw-grid.btfw-grid--chat-right{
-  grid-template-columns: minmax(520px,1fr) var(--btfw-split-width) minmax(var(--btfw-chat-min),var(--btfw-chat-max));
+  grid-template-columns: minmax(520px,7fr) var(--btfw-split-width) minmax(var(--btfw-chat-min),3fr);
   grid-template-areas:
     "nav nav nav"
     "video split chat";
@@ -256,7 +256,8 @@ a:hover {
 
 /* ---------- Content Stack under video ---------- */
 #btfw-stack{
-  display:block;
+  display:flex;
+  flex-direction:column;
   flex: 1; /* Take remaining space in leftpad */
   min-height: 0; /* Allow shrinking */
 }
@@ -277,8 +278,11 @@ a:hover {
 }
 #btfw-stack .btfw-stack-title{ font-weight:600; opacity:.9; }
 #btfw-stack .btfw-stack-list{
-  display:flex; flex-direction:column; gap: var(--btfw-gap);
+  display:flex;
+  flex-direction:column;
+  gap: var(--btfw-gap);
   margin-top: var(--btfw-gap);
+  flex: 1;
 }
 .btfw-stack-item{
   border:1px solid var(--btfw-border);
@@ -669,6 +673,7 @@ a:hover {
 #btfw-stack-footer {
   margin-top: auto;
   padding: clamp(18px, 4vw, 28px) clamp(18px, 4vw, 32px);
+  background: var(--btfw-color-panel);
   background: linear-gradient(180deg,
     color-mix(in srgb, var(--btfw-color-panel) 94%, transparent 6%),
     color-mix(in srgb, var(--btfw-color-surface) 90%, transparent 10%));

--- a/css/chat.css
+++ b/css/chat.css
@@ -497,7 +497,7 @@ img.twemoji { width: 1em; height: 1em; vertical-align: -0.15em; }
   color: var(--btfw-name-color) !important;
 }
 
-:root { --btfw-avatar-size: 24px; }
+:root { --btfw-avatar-size: 40px; }
 
 #messagebuffer .btfw-chat-avatarwrap { display:inline-block; margin-right:6px; vertical-align:middle; }
 #messagebuffer .btfw-chat-avatar {

--- a/css/player.css
+++ b/css/player.css
@@ -30,10 +30,11 @@
 #videowrap .embed-responsive iframe,
 #videowrap .embed-responsive object,
 #videowrap .embed-responsive video{
-  position: static;
-  top: auto;
-  left: auto;
-  bottom: auto;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
   width: 100%;
   height: 100%;
   display: block;
@@ -71,7 +72,9 @@
   padding: 12px 16px;
   margin: 0 0 8px;
   border-radius: 14px;
+  background: var(--btfw-color-panel);
   background: color-mix(in srgb, var(--btfw-color-panel) 92%, transparent 8%);
+  border: 1px solid var(--btfw-border, rgba(109, 77, 246, 0.2));
   border: 1px solid color-mix(in srgb, var(--btfw-color-accent) 20%, transparent 80%);
   box-shadow: 0 12px 28px color-mix(in srgb, var(--btfw-color-bg) 45%, transparent 55%);
   color: var(--btfw-color-text);
@@ -80,6 +83,7 @@
 
 #queue li.queue_entry:hover,
 .queue_entry:hover {
+  background: var(--btfw-color-panel);
   background: color-mix(in srgb, var(--btfw-color-panel) 88%, transparent 12%);
   border-color: color-mix(in srgb, var(--btfw-color-accent) 38%, transparent 62%);
   transform: translateY(-1px);
@@ -111,6 +115,7 @@
   font-size: 0.8rem;
   padding: 4px 10px;
   border-radius: 999px;
+  background: var(--btfw-color-accent);
   background: color-mix(in srgb, var(--btfw-color-accent) 18%, transparent 82%);
   color: color-mix(in srgb, var(--btfw-color-text) 96%, white 4%);
   font-weight: 600;

--- a/modules/feature-channels.js
+++ b/modules/feature-channels.js
@@ -160,7 +160,8 @@ BTFW.define("feature:channels", [], async () => {
       }
 
       .btfw-channels__item {
-        flex: 0 0 210px;
+        flex: 0 0 clamp(160px, 18vw, 220px);
+        max-width: clamp(160px, 18vw, 220px);
       }
 
       .btfw-channels__link {
@@ -169,6 +170,7 @@ BTFW.define("feature:channels", [], async () => {
         gap: 8px;
         text-decoration: none;
         color: color-mix(in srgb, var(--btfw-theme-text, #e8ecfb) 96%, transparent 4%);
+        background: var(--btfw-theme-surface, #0b111d);
         background: color-mix(in srgb, var(--btfw-theme-surface, #0b111d) 88%, transparent 12%);
         border-radius: 12px;
         border: 1px solid color-mix(in srgb, var(--btfw-theme-accent, #6d4df6) 22%, transparent 78%);
@@ -189,8 +191,10 @@ BTFW.define("feature:channels", [], async () => {
 
       .btfw-channels__media {
         position: relative;
+        width: 100%;
         aspect-ratio: 16 / 9;
         overflow: hidden;
+        background: var(--btfw-theme-panel, #141f36);
         background: color-mix(in srgb, var(--btfw-theme-panel, #141f36) 88%, black 12%);
       }
 

--- a/modules/feature-chat-avatars.js
+++ b/modules/feature-chat-avatars.js
@@ -14,7 +14,7 @@ BTFW.define("feature:chat-avatars", [], async () => {
       const stored = localStorage.getItem(AVATAR_KEY);
       if (stored === "off" || stored === "big" || stored === "small") return stored;
     } catch(_) {}
-    return "small";
+    return "big";
   }
 
   function saveMode(mode){

--- a/modules/feature-layout.js
+++ b/modules/feature-layout.js
@@ -69,10 +69,14 @@ BTFW.define("feature:layout", ["feature:styleCore","feature:bulma"], async ({}) 
     }
 
     const stored = videoColumnPx ? Math.max(videoColumnPx, VIDEO_MIN_PX) : null;
+    const fallbackVideo = `minmax(${VIDEO_MIN_PX}px, 7fr)`;
+    const fallbackChat = "minmax(var(--btfw-chat-min, 320px), 3fr)";
     const videoSegment = stored
       ? `minmax(${VIDEO_MIN_PX}px, ${stored}px)`
-      : `minmax(${VIDEO_MIN_PX}px, 1fr)`;
-    const chatSegment = "minmax(var(--btfw-chat-min, 320px), 1fr)";
+      : fallbackVideo;
+    const chatSegment = stored
+      ? "minmax(var(--btfw-chat-min, 320px), 1fr)"
+      : fallbackChat;
     const template = chatSidePref === "left"
       ? `${chatSegment} var(--btfw-split-width, 8px) ${videoSegment}`
       : `${videoSegment} var(--btfw-split-width, 8px) ${chatSegment}`;

--- a/modules/feature-stack.js
+++ b/modules/feature-stack.js
@@ -248,12 +248,13 @@ BTFW.define("feature:stack", ["feature:layout"], async ({}) => {
     const playlistWrap = document.getElementById("playlistwrap");
     const queueContainer = document.getElementById("queuecontainer");
     const playlistRow = document.getElementById("playlistrow");
+    const stackPlaylist = document.querySelector('#btfw-stack .btfw-stack-item[data-bind="playlist-group"] .btfw-stack-item__body');
 
     // Find any floating controls row (legacy CyTube layout)
     const controlsRows = document.querySelectorAll(".btfw-controls-row");
 
     // Find the main playlist container
-    const mainContainer = playlistRow || playlistWrap || queueContainer;
+    let mainContainer = playlistRow || playlistWrap || queueContainer || stackPlaylist;
     if (!mainContainer) return;
 
     // Create or enhance the playlist bar
@@ -344,9 +345,9 @@ BTFW.define("feature:stack", ["feature:layout"], async ({}) => {
 
     const moveControls = (root) => {
       if (!root) return;
-      Array.from(root.childNodes).forEach(node => {
-        if (!node || node.nodeType !== 1) return;
-        const el = node;
+      const elements = Array.from(root.children || []);
+      elements.forEach(el => {
+        if (!el) return;
         el.classList.add("btfw-plbar__control");
         actionsCluster.appendChild(el);
       });

--- a/modules/feature-theme-settings.js
+++ b/modules/feature-theme-settings.js
@@ -273,7 +273,7 @@ BTFW.define("feature:themeSettings", [], async () => {
 
     // gather current values
     const themeMode   = ($$('input[name="btfw-theme-mode"]:checked', m)[0]?.value) || "dark";
-    const avatarsMode = ($$('input[name="btfw-avatars-mode"]:checked', m)[0]?.value) || "small";
+    const avatarsMode = ($$('input[name="btfw-avatars-mode"]:checked', m)[0]?.value) || "big";
     const chatTextPx  = $("#btfw-chat-textsize", m)?.value || "14";
     const emoteSize   = $("#btfw-emote-size", m)?.value   || "medium";
     const gifAutoOn   = $("#btfw-gif-autoplay", m)?.checked;
@@ -334,7 +334,7 @@ BTFW.define("feature:themeSettings", [], async () => {
       }
     });
 
-    const storedAv = get(TS_KEYS.avatarsMode,"small");
+    const storedAv = get(TS_KEYS.avatarsMode,"big");
     const avNow = avatarsModule?.getMode ? avatarsModule.getMode() : storedAv;
     $$('input[name="btfw-avatars-mode"]').forEach(i => i.checked = (i.value === avNow));
     resolveAvatars().then(mod => {


### PR DESCRIPTION
## Summary
- restore absolute positioning for legacy embed-responsive players and add fallback colors so the video area and queue styling match across browsers
- default the desktop grid to a 70/30 video-to-chat split, flex the stack so its footer stays pinned, and harden playlist control migration so rightcontrols stays with the playlist on Firefox
- set chat avatars to use the big size by default and clamp featured channel tiles to a consistent footprint with cross-browser friendly styling

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d58119a8688329a7a93acb766067df