### PR TITLE
Improve mobile layout, player theme, and chat alignment

### DIFF
--- a/css/chat.css
+++ b/css/chat.css
@@ -70,16 +70,19 @@
   -webkit-overflow-scrolling: touch;
 }
 
-#messagebuffer .chat-msg{
+#messagebuffer > div {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   align-items: flex-start;
-  gap: 6px;
-  padding: 3px 6px;
+  gap: 8px;
+  padding: 4px 10px;
   position: relative;
+  width: 100%;
+  box-sizing: border-box;
 }
-#messagebuffer .timestamp{
-  order: 99;
+
+#messagebuffer > div .timestamp {
+  order: 3;
   margin-left: auto !important;
   display: inline-flex;
   align-items: center;
@@ -93,15 +96,38 @@
   padding-left: 12px;
   color: color-mix(in srgb, var(--btfw-color-chat-text) 70%, transparent 30%);
 }
-#messagebuffer .username{
-  order: 1;
-  font-weight: 600;
-  margin-right: 0;
-}
-#messagebuffer .chat-msg > span:not(.timestamp):not(.username){
+
+#messagebuffer > div span.timestamp ~ span {
   order: 2;
+  display: inline-flex;
+  align-items: flex-start;
+  gap: 6px;
+  flex: 0 0 auto;
+}
+
+#messagebuffer > div span.timestamp + span {
+  flex-wrap: nowrap;
+}
+
+#messagebuffer > div span.timestamp ~ span:last-child {
   flex: 1 1 auto;
   min-width: 0;
+  word-break: break-word;
+}
+
+#messagebuffer > div.btfw-has-avatar span.timestamp + span {
+  align-items: center;
+}
+
+#messagebuffer > div span .username,
+#messagebuffer > div span .nick,
+#messagebuffer > div span .name {
+  font-weight: 600;
+}
+
+#messagebuffer > div.server-msg,
+#messagebuffer > div.server-msg-reconnect {
+  display: block;
 }
 
 /* Keep images/GIFs reasonable inside chat */
@@ -338,22 +364,6 @@
   #btfw-ct-modal .btfw-ct-grid{ grid-template-columns: repeat(3, minmax(80px,1fr)); }
 }
 
-#messagebuffer .chat-msg.btfw-has-avatar {
-  display: flex;
-  align-items: flex-start;
-  gap: 8px;
-  padding: 4px 2px;
-}
-#messagebuffer .chat-msg.btfw-has-avatar .username,
-#messagebuffer .chat-msg.btfw-has-avatar .nick,
-#messagebuffer .chat-msg.btfw-has-avatar .name {
-  vertical-align: middle;
-}
-
-/* Consecutive messages from same user: hide avatar and tighten spacing */
-#messagebuffer .chat-msg.btfw-consecutive .btfw-chat-avatar { visibility: hidden; width: 0 !important; height: 0 !important; margin: 0 !important; }
-#messagebuffer .chat-msg.btfw-consecutive { padding-top: 2px; }
-
 /* Fallback quick control styling (if Theme Settings modal is absent) */
 .btfw-avatars-dd .btfw-avatars-select{
   background: color-mix(in srgb, var(--btfw-color-panel) 80%, transparent 20%);
@@ -413,22 +423,6 @@
 #chatwrap.btfw-avatars-off  .btfw-chat-avatarwrap { display: none !important; }
 #chatwrap.btfw-avatars-small .btfw-chat-avatar { width: 28px; height: 28px; border-radius: 8px; }
 #chatwrap.btfw-avatars-big   .btfw-chat-avatar { width: 40px; height: 40px; border-radius: 10px; }
-
-/* When we add an avatar, make the root a row with gaps */
-#messagebuffer .btfw-has-avatar{
-  display: flex;
-  align-items: flex-start;
-  gap: 8px;
-  padding: 4px 2px;
-}
-
-/* Consecutive messages from the same user: hide avatar on following lines */
-#messagebuffer .btfw-consecutive > .btfw-chat-avatar{
-  visibility: hidden;
-  width: 0 !important;
-  height: 0 !important;
-  margin: 0 !important;
-}
 
 /* Inline emoji images sized like text */
 img.twemoji { width: 1em; height: 1em; vertical-align: -0.15em; }
@@ -499,15 +493,25 @@ img.twemoji { width: 1em; height: 1em; vertical-align: -0.15em; }
 
 :root { --btfw-avatar-size: 40px; }
 
-#messagebuffer .btfw-chat-avatarwrap { display:inline-block; margin-right:6px; vertical-align:middle; }
+#messagebuffer .btfw-chat-avatarwrap {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 6px;
+  flex: 0 0 var(--btfw-avatar-size);
+  width: var(--btfw-avatar-size);
+  height: var(--btfw-avatar-size);
+  vertical-align: middle;
+}
 #messagebuffer .btfw-chat-avatar {
   width: var(--btfw-avatar-size);
   height: var(--btfw-avatar-size);
   border-radius: 6px;
   object-fit: cover;
+  display: block;
 }
 
-/* consecutive compaction: remove top gap, hide avatar (JS toggles) */
+/* consecutive compaction: remove top gap */
 #messagebuffer > div.btfw-compact { margin-top: 2px !important; }
 
 /* hide timestamps when off */

--- a/css/mobile.css
+++ b/css/mobile.css
@@ -7,15 +7,15 @@
 /* --------- Tablet & down (<= 1100px): stack columns, unstick chat --------- */
 @media (max-width: 1100px){
   #btfw-grid.btfw-grid--vertical{
-    padding: 0 8px;
-    margin-top: calc(var(--btfw-top,48px) + 8px);
-    min-height: calc(100vh - var(--btfw-top,48px) - 8px);
+    padding: var(--btfw-gap, 10px) 8px;
+    margin-top: 0;
+    min-height: auto;
     height: auto;
   }
 
   #btfw-grid.btfw-grid--vertical #btfw-chatcol{
     height: auto;
-    min-height: 420px;
+    min-height: clamp(320px, 55vh, 520px);
   }
 }
 

--- a/css/navbar.css
+++ b/css/navbar.css
@@ -19,11 +19,9 @@
   border-bottom: 1px solid var(--btfw-navbar-divider, color-mix(in srgb, var(--btfw-border) 86%, transparent 14%));
   background:
     linear-gradient(180deg,
-      color-mix(in srgb, var(--btfw-color-bg) 76%, transparent 24%),
-      color-mix(in srgb, var(--btfw-color-surface) 88%, transparent 12%));
+      color-mix(in srgb, var(--btfw-color-bg) 82%, transparent 18%),
+      color-mix(in srgb, var(--btfw-color-surface) 92%, transparent 8%));
   background-image: none !important;
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
   box-shadow: 0 12px 28px color-mix(in srgb, var(--btfw-color-bg) 58%, transparent 42%);
   display: flex;
   align-items: center;
@@ -237,6 +235,33 @@
   #btfw-navhost .nav > li > a {
     width: 100%;
     justify-content: space-between;
+  }
+}
+
+@media (max-width: 768px) {
+  :root { --btfw-navbar-height: 52px; }
+
+  #btfw-navhost > nav.navbar,
+  #btfw-navhost > .navbar,
+  #btfw-navhost > #navbar,
+  #btfw-navhost > .navbar-fixed-top {
+    min-height: var(--btfw-navbar-height);
+    box-shadow: 0 8px 18px color-mix(in srgb, var(--btfw-color-bg) 46%, transparent 54%);
+  }
+
+  #btfw-navhost > nav.navbar .container,
+  #btfw-navhost > .navbar .container {
+    padding: 0 clamp(14px, 4vw, 22px);
+    gap: clamp(10px, 3vw, 18px);
+  }
+
+  #btfw-navhost .navbar-header {
+    min-height: var(--btfw-navbar-height);
+  }
+
+  #btfw-navhost .navbar-nav > li > a,
+  #btfw-navhost .nav > li > a {
+    padding: 9px 12px;
   }
 }
 

--- a/css/overlays.css
+++ b/css/overlays.css
@@ -189,13 +189,17 @@
 }
 /* --- BTFW Emotes Popover (mini) --- */
 /* Fixed-size popover container (JS sets an explicit height) */
+.btfw-popover {
+  max-width: calc(100vw - 16px);
+}
+
 #btfw-emotes-pop {
   position: absolute;
   right: 8px;
   bottom: 56px;            /* JS overrides; keep as safe fallback */
-  width: 520px;            /* JS adjusts within 320–560 */
+  width: min(520px, calc(100vw - 16px));
   height: 360px;           /* fallback; JS sets exact height per open */
-  max-width: calc(100% - 16px);
+  max-width: calc(100vw - 16px);
   display: flex;
   flex-direction: column;
   background: color-mix(in srgb, var(--btfw-overlay-bg) 94%, transparent 6%);

--- a/modules/feature-chat.js
+++ b/modules/feature-chat.js
@@ -22,12 +22,44 @@ function positionAboveChatBar(el, opts){
   const cwRect  = cw.getBoundingClientRect();
   const barRect = bar.getBoundingClientRect();
 
+  const safeMargin = Math.max(6, margin);
+  const viewportLimitPx = isFinite(widthVw) ? (window.innerWidth * (widthVw / 100)) : widthPx;
+  const availableViewport = Math.max(0, window.innerWidth - safeMargin * 2);
+  const availableWithinChat = Math.max(0, cwRect.width - safeMargin * 2);
+
+  let width = Math.min(widthPx, viewportLimitPx, availableViewport || widthPx);
+  if (availableWithinChat > 0) {
+    width = Math.min(width, availableWithinChat);
+  }
+
+  const minComfort = Math.min(widthPx, viewportLimitPx, availableViewport || widthPx);
+  if (width < 280 && minComfort >= 280) {
+    width = Math.min(minComfort, Math.max(width, 280));
+  }
+
+  if (!Number.isFinite(width) || width <= 0) {
+    width = Math.min(widthPx, viewportLimitPx, availableViewport || widthPx);
+  }
+
+  const left = Math.max(safeMargin, cwRect.right - width);
+  const bottomOffset = Math.max(safeMargin, window.innerHeight - barRect.top + safeMargin);
+
+  const maxHeightViewport = isFinite(maxHvh) ? window.innerHeight * (maxHvh / 100) : maxHpx;
+  const availableHeight = Math.max(0, barRect.top - safeMargin);
+  const maxHeight = Math.min(maxHpx, maxHeightViewport, availableHeight || maxHpx);
+
   // Make it a fixed overlay and tuck it into the chat’s right edge
   el.style.position  = "fixed";
-  el.style.right     = Math.max(margin, window.innerWidth  - cwRect.right + margin) + "px";
-  el.style.bottom    = Math.max(margin, window.innerHeight - barRect.top   + margin) + "px";
-  el.style.width     = `min(${widthPx}px, ${widthVw}vw)`;
-  el.style.maxHeight = `min(${maxHpx}px, ${maxHvh}vh)`;
+  el.style.left      = `${Math.round(left)}px`;
+  el.style.right     = "auto";
+  el.style.bottom    = `${Math.round(bottomOffset)}px`;
+  el.style.width     = `${Math.round(width)}px`;
+  el.style.maxWidth  = `${Math.round(Math.min(widthPx, viewportLimitPx, Math.max(width, availableWithinChat || width, availableViewport || width)))}px`;
+  if (Number.isFinite(maxHeight) && maxHeight > 0) {
+    el.style.maxHeight = `${Math.round(maxHeight)}px`;
+  } else {
+    el.style.removeProperty("max-height");
+  }
   el.style.zIndex    = el.style.zIndex || "6002"; // keep above chat, below navbar modals
 }
 /* expose so other modules can use it */

--- a/modules/feature-footer.js
+++ b/modules/feature-footer.js
@@ -119,8 +119,40 @@ BTFW.define("feature:footer", [], async () => {
   }
 
   function ensureFooterSlot(){
-    const stacked = document.querySelector("#btfw-stack-footer .btfw-footer .container");
-    if (stacked) return stacked;
+    const stackContainer = document.getElementById("btfw-stack-footer");
+    if (stackContainer) {
+      const stray = document.getElementById("btfw-footer");
+      const strayChildren = [];
+      if (stray && stray !== stackContainer && !stackContainer.contains(stray)) {
+        while (stray.firstChild) {
+          strayChildren.push(stray.firstChild);
+        }
+        stray.remove();
+      }
+
+      let host = stackContainer.querySelector("#btfw-footer") || stackContainer.querySelector(".btfw-footer");
+      if (!host) {
+        host = document.createElement("div");
+        host.id = "btfw-footer";
+        host.className = "btfw-footer";
+        stackContainer.appendChild(host);
+      } else {
+        host.id = "btfw-footer";
+        host.classList.add("btfw-footer");
+      }
+
+      strayChildren.forEach(node => host.appendChild(node));
+
+      // Merge any duplicate footer nodes into the primary host
+      stackContainer.querySelectorAll("#btfw-footer ~ .btfw-footer, #btfw-footer ~ #btfw-footer").forEach(extra => {
+        if (extra === host) return;
+        while (extra.firstChild) host.appendChild(extra.firstChild);
+        extra.remove();
+      });
+
+      host.classList.remove("btfw-footer--standalone");
+      return host;
+    }
 
     let host = $("#btfw-footer") || $(".btfw-footer");
     if (!host) {
@@ -130,7 +162,6 @@ BTFW.define("feature:footer", [], async () => {
       const stack = $("#btfw-content-stack") || $("#mainpage") || $("#main") || document.body;
       stack.appendChild(host);
     }
-    host.classList.add("btfw-footer--standalone");
     return host;
   }
 

--- a/modules/feature-player.js
+++ b/modules/feature-player.js
@@ -3,7 +3,6 @@ BTFW.define("feature:player", ["feature:layout"], async ({}) => {
   const THEME_ID = "btfw-videojs-zen-theme";
 
   // Zen-inspired VideoJS theme CSS - clean, minimal, modern
-  // Uses !important to override default VideoJS styles
   const videoPlayerThemeCSS = `
     /* Zen Theme - Clean & Minimal Video.js Styling - Override Default */
     .video-js {
@@ -32,11 +31,10 @@ BTFW.define("feature:player", ["feature:layout"], async ({}) => {
     .video-js .vjs-control-bar {
       display: flex !important;
       align-items: center !important;
-      background: linear-gradient(to top, 
-        rgba(0, 0, 0, 0.9) 0%, 
-        rgba(0, 0, 0, 0.7) 50%, 
+      background: linear-gradient(to top,
+        rgba(0, 0, 0, 0.9) 0%,
+        rgba(0, 0, 0, 0.7) 50%,
         transparent 100%) !important;
-      backdrop-filter: blur(12px) !important;
       border: none !important;
       height: 56px !important;
       padding: 0 16px !important;
@@ -213,8 +211,8 @@ BTFW.define("feature:player", ["feature:layout"], async ({}) => {
 
     .video-js .vjs-play-progress {
       background: var(--btfw-color-accent, #6d4df6) !important;
-      background: linear-gradient(90deg, 
-        var(--btfw-color-accent, #6d4df6), 
+      background: linear-gradient(90deg,
+        var(--btfw-color-accent, #6d4df6),
         color-mix(in srgb, var(--btfw-color-accent, #6d4df6) 85%, #fff 15%)
       ) !important;
       border-radius: 6px !important;
@@ -245,7 +243,6 @@ BTFW.define("feature:player", ["feature:layout"], async ({}) => {
     /* Time tooltips */
     .video-js .vjs-time-tooltip {
       background: rgba(0, 0, 0, 0.9) !important;
-      backdrop-filter: blur(8px) !important;
       color: #fff !important;
       padding: 6px 10px !important;
       border-radius: 6px !important;
@@ -264,7 +261,6 @@ BTFW.define("feature:player", ["feature:layout"], async ({}) => {
       width: 88px !important;
       height: 88px !important;
       background: rgba(0, 0, 0, 0.8) !important;
-      backdrop-filter: blur(12px) !important;
       border: 3px solid rgba(255, 255, 255, 0.3) !important;
       border-radius: 50% !important;
       color: #fff !important;
@@ -325,7 +321,6 @@ BTFW.define("feature:player", ["feature:layout"], async ({}) => {
     /* Error display */
     .video-js .vjs-error-display {
       background: rgba(0, 0, 0, 0.9) !important;
-      backdrop-filter: blur(12px) !important;
       color: #fff !important;
       border-radius: 12px !important;
       margin: 24px !important;
@@ -353,7 +348,6 @@ BTFW.define("feature:player", ["feature:layout"], async ({}) => {
 
     .video-js .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
       background: rgba(0, 0, 0, 0.95) !important;
-      backdrop-filter: blur(16px) !important;
       border: 1px solid rgba(255, 255, 255, 0.15) !important;
       border-radius: 12px !important;
       min-width: 140px !important;
@@ -408,32 +402,14 @@ BTFW.define("feature:player", ["feature:layout"], async ({}) => {
     }
 
     /* Hide unwanted default controls */
-    .video-js .vjs-remaining-time { 
-      display: none !important; 
-    }
-    
-    .video-js .vjs-picture-in-picture-control { 
-      display: none !important; 
-    }
-
-    .video-js .vjs-playback-rate.vjs-hidden { 
-      display: none !important; 
-    }
-
-    .video-js .vjs-chapters-button.vjs-hidden { 
-      display: none !important; 
-    }
-
-    .video-js .vjs-descriptions-button.vjs-hidden { 
-      display: none !important; 
-    }
-
-    .video-js .vjs-subs-caps-button.vjs-hidden { 
-      display: none !important; 
-    }
-
-    .video-js .vjs-audio-button.vjs-hidden { 
-      display: none !important; 
+    .video-js .vjs-remaining-time,
+    .video-js .vjs-picture-in-picture-control,
+    .video-js .vjs-playback-rate.vjs-hidden,
+    .video-js .vjs-chapters-button.vjs-hidden,
+    .video-js .vjs-descriptions-button.vjs-hidden,
+    .video-js .vjs-subs-caps-button.vjs-hidden,
+    .video-js .vjs-audio-button.vjs-hidden {
+      display: none !important;
     }
 
     /* Mobile optimizations */
@@ -478,20 +454,42 @@ BTFW.define("feature:player", ["feature:layout"], async ({}) => {
     }
   `;
 
-  function applyPlayerTheme() {
-    if (document.getElementById(THEME_ID)) return;
-    const style = document.createElement("style");
-    style.id = THEME_ID;
-    style.type = "text/css";
-    style.appendChild(document.createTextNode(videoPlayerThemeCSS));
-    document.head.appendChild(style);
+  function ensureThemeStyle() {
+    const head = document.head || document.getElementsByTagName("head")[0];
+    if (!head) return null;
+    let style = document.getElementById(THEME_ID);
+    if (!style) {
+      style = document.createElement("style");
+      style.id = THEME_ID;
+      style.type = "text/css";
+      style.appendChild(document.createTextNode(videoPlayerThemeCSS));
+    } else if (!style.firstChild || style.textContent !== videoPlayerThemeCSS) {
+      style.textContent = videoPlayerThemeCSS;
+    }
+    head.appendChild(style); // appending moves it to the end so it overrides legacy styles
+    return style;
+  }
+
+  const LEGACY_CLASS_REGEX = /^(?:vjs-default-skin|vjs-theme-.*)$/;
+
+  function stripLegacySkinClasses() {
+    document.querySelectorAll(".video-js").forEach((player) => {
+      const classesToRemove = Array.from(player.classList).filter((cls) => LEGACY_CLASS_REGEX.test(cls));
+      classesToRemove.forEach((cls) => player.classList.remove(cls));
+      player.classList.add("btfw-videojs-themed");
+    });
+  }
+
+  function ensureTheme() {
+    ensureThemeStyle();
+    stripLegacySkinClasses();
   }
 
   /* ===== Guard: block context menu + surface click-to-pause ===== */
   const GUARD_MARK = "_btfwGuarded";
 
   function shouldAllowClick(target) {
-    // Allow clicks on any control UI
+    if (!target) return false;
     if (target.closest(".vjs-control-bar,.vjs-control,.vjs-menu,.vjs-menu-content,.vjs-slider,.vjs-volume-panel")) {
       return true;
     }
@@ -502,29 +500,27 @@ BTFW.define("feature:player", ["feature:layout"], async ({}) => {
     if (!el || el[GUARD_MARK]) return;
     el[GUARD_MARK] = true;
 
-    // No right-click menu
     el.addEventListener("contextmenu", (e) => {
       e.preventDefault();
       e.stopPropagation();
       return false;
     }, true);
 
-    // Block surface left-click (capture) so Video.js doesn't toggle pause
     const block = (e) => {
-      // Only block direct video surface / poster / spinner, not controls
       if (shouldAllowClick(e.target)) return;
-      // Only block primary button
       if (e.type === "click" && e.button !== 0) return;
       e.preventDefault();
       e.stopImmediatePropagation();
     };
+
     el.addEventListener("click", block, true);
-    el.addEventListener("pointerdown", (e)=> { if (!shouldAllowClick(e.target) && e.button===0) e.preventDefault(); }, true);
+    el.addEventListener("pointerdown", (e) => {
+      if (!shouldAllowClick(e.target) && e.button === 0) e.preventDefault();
+    }, true);
     el.addEventListener("touchstart", block, true);
   }
 
   function attachGuards() {
-    // CyTube container + Video.js root + tech element
     const candidates = [
       ...document.querySelectorAll("#ytapiplayer"),
       ...document.querySelectorAll(".video-js"),
@@ -535,484 +531,46 @@ BTFW.define("feature:player", ["feature:layout"], async ({}) => {
     candidates.forEach(attachGuardsTo);
   }
 
-  /* ===== Observe player mount/reloads ===== */
-  let mo = null;
   function watchPlayerMount() {
     const target = document.getElementById("videowrap") || document.body;
-    if (mo) { try { mo.disconnect(); } catch(_){} mo = null; }
-    mo = new MutationObserver(() => {
-      // Each mutation pass: ensure theme + guards
-      applyPlayerTheme();
+    if (!target) return;
+    if (watchPlayerMount._mo) {
+      try { watchPlayerMount._mo.disconnect(); } catch (_) {}
+    }
+    const mo = new MutationObserver(() => {
+      ensureTheme();
       attachGuards();
     });
     mo.observe(target, { childList: true, subtree: true });
+    watchPlayerMount._mo = mo;
+  }
+
+  function watchHead() {
+    const head = document.head;
+    if (!head || watchHead._mo) return;
+    const mo = new MutationObserver(() => ensureThemeStyle());
+    mo.observe(head, { childList: true });
+    watchHead._mo = mo;
   }
 
   function boot() {
-    applyPlayerTheme();
+    ensureTheme();
     attachGuards();
     watchPlayerMount();
+    watchHead();
   }
 
-  // Boot on ready and when layout signals ready
   if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", boot);
   } else {
     boot();
   }
+
   document.addEventListener("btfw:layoutReady", () => setTimeout(boot, 0));
 
   return {
     name: "feature:player",
-    applyTheme: applyPlayerTheme,
-    attachGuards
-  };
-});/* BTFW — feature:player (VideoJS player theming, tech guards, responsive fit) */
-BTFW.define("feature:player", ["feature:layout"], async ({}) => {
-  const THEME_ID = "btfw-videojs-zen-theme";
-
-  // Zen-inspired VideoJS theme CSS - clean, minimal, modern
-  const videoPlayerThemeCSS = `
-    /* Zen Theme - Clean & Minimal Video.js Styling */
-    .video-js {
-      font-family: var(--btfw-theme-font-family, 'Inter', sans-serif);
-      font-size: 14px;
-      line-height: 1.4;
-      color: #fff;
-      background-color: #000;
-      position: relative;
-      vertical-align: top;
-      box-sizing: border-box;
-      background-size: cover;
-      background-position: center;
-      user-select: none;
-      border-radius: 12px;
-      overflow: hidden;
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
-    }
-
-    /* Control bar - sleek and minimal */
-    .video-js .vjs-control-bar {
-      display: flex;
-      align-items: center;
-      background: linear-gradient(to top, 
-        rgba(0, 0, 0, 0.8) 0%, 
-        rgba(0, 0, 0, 0.6) 50%, 
-        transparent 100%);
-      backdrop-filter: blur(8px);
-      border: none;
-      height: 48px;
-      padding: 0 12px;
-      transition: opacity 0.3s ease, transform 0.3s ease;
-    }
-
-    .video-js:not(.vjs-user-inactive) .vjs-control-bar {
-      transform: translateY(0);
-      opacity: 1;
-    }
-
-    .video-js.vjs-user-inactive .vjs-control-bar {
-      transform: translateY(8px);
-      opacity: 0;
-    }
-
-    /* Buttons - clean circular design */
-    .video-js .vjs-button {
-      background: transparent;
-      border: none;
-      color: #fff;
-      cursor: pointer;
-      margin: 0 4px;
-      padding: 8px;
-      border-radius: 50%;
-      width: 36px;
-      height: 36px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      transition: all 0.2s ease;
-      position: relative;
-    }
-
-    .video-js .vjs-button:hover,
-    .video-js .vjs-button:focus {
-      background: rgba(255, 255, 255, 0.15);
-      transform: scale(1.05);
-      outline: none;
-    }
-
-    .video-js .vjs-button:active {
-      transform: scale(0.95);
-    }
-
-    /* Play/Pause button - slightly larger */
-    .video-js .vjs-play-control {
-      width: 44px;
-      height: 44px;
-      margin-right: 8px;
-    }
-
-    /* Progress control - modern slider */
-    .video-js .vjs-progress-control {
-      flex: auto;
-      display: flex;
-      align-items: center;
-      margin: 0 12px;
-      height: 6px;
-      background: rgba(255, 255, 255, 0.2);
-      border-radius: 3px;
-      cursor: pointer;
-      transition: height 0.2s ease;
-    }
-
-    .video-js .vjs-progress-control:hover {
-      height: 8px;
-    }
-
-    .video-js .vjs-progress-holder {
-      flex: auto;
-      display: flex;
-      align-items: center;
-      height: 100%;
-      margin: 0;
-      background: transparent;
-      border-radius: 3px;
-    }
-
-    .video-js .vjs-play-progress {
-      background: var(--btfw-color-accent, #6d4df6);
-      background: linear-gradient(90deg, 
-        var(--btfw-color-accent, #6d4df6), 
-        color-mix(in srgb, var(--btfw-color-accent, #6d4df6) 80%, #fff 20%)
-      );
-      border-radius: 3px;
-      height: 100%;
-      position: relative;
-    }
-
-    .video-js .vjs-play-progress:before {
-      content: '';
-      position: absolute;
-      top: 50%;
-      right: -6px;
-      transform: translateY(-50%);
-      width: 12px;
-      height: 12px;
-      background: #fff;
-      border-radius: 50%;
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-      opacity: 0;
-      transition: opacity 0.2s ease;
-    }
-
-    .video-js .vjs-progress-control:hover .vjs-play-progress:before {
-      opacity: 1;
-    }
-
-    .video-js .vjs-load-progress {
-      background: rgba(255, 255, 255, 0.3);
-      border-radius: 3px;
-      height: 100%;
-    }
-
-    /* Time displays */
-    .video-js .vjs-current-time,
-    .video-js .vjs-duration,
-    .video-js .vjs-time-divider {
-      display: block;
-      flex: none;
-      font-size: 12px;
-      font-weight: 500;
-      color: rgba(255, 255, 255, 0.9);
-      padding: 0;
-      margin: 0 4px;
-      line-height: 1;
-      min-width: auto;
-    }
-
-    .video-js .vjs-time-divider {
-      padding: 0 2px;
-    }
-
-    /* Volume control */
-    .video-js .vjs-volume-panel {
-      display: flex;
-      align-items: center;
-    }
-
-    .video-js .vjs-volume-control {
-      width: 0;
-      transition: width 0.3s ease;
-      overflow: hidden;
-    }
-
-    .video-js .vjs-volume-panel:hover .vjs-volume-control {
-      width: 80px;
-    }
-
-    .video-js .vjs-volume-bar {
-      background: rgba(255, 255, 255, 0.2);
-      border-radius: 2px;
-      height: 4px;
-      margin: 0 8px;
-    }
-
-    .video-js .vjs-volume-level {
-      background: var(--btfw-color-accent, #6d4df6);
-      border-radius: 2px;
-      height: 100%;
-    }
-
-    /* Fullscreen button */
-    .video-js .vjs-fullscreen-control {
-      margin-left: 4px;
-    }
-
-    /* Big play button - clean centered design */
-    .video-js .vjs-big-play-button {
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-      width: 80px;
-      height: 80px;
-      background: rgba(0, 0, 0, 0.7);
-      backdrop-filter: blur(8px);
-      border: 2px solid rgba(255, 255, 255, 0.3);
-      border-radius: 50%;
-      color: #fff;
-      font-size: 24px;
-      transition: all 0.3s ease;
-      cursor: pointer;
-    }
-
-    .video-js .vjs-big-play-button:hover,
-    .video-js .vjs-big-play-button:focus {
-      background: rgba(0, 0, 0, 0.9);
-      border-color: var(--btfw-color-accent, #6d4df6);
-      transform: translate(-50%, -50%) scale(1.05);
-      outline: none;
-    }
-
-    .video-js .vjs-big-play-button:active {
-      transform: translate(-50%, -50%) scale(0.95);
-    }
-
-    .video-js .vjs-big-play-button .vjs-icon-placeholder:before {
-      position: absolute;
-      top: 50%;
-      left: 55%;
-      transform: translate(-50%, -50%);
-    }
-
-    /* Loading spinner */
-    .video-js .vjs-loading-spinner {
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-      border: 3px solid rgba(255, 255, 255, 0.2);
-      border-top: 3px solid var(--btfw-color-accent, #6d4df6);
-      border-radius: 50%;
-      width: 40px;
-      height: 40px;
-      animation: vjs-spin 1s linear infinite;
-    }
-
-    @keyframes vjs-spin {
-      0% { transform: translate(-50%, -50%) rotate(0deg); }
-      100% { transform: translate(-50%, -50%) rotate(360deg); }
-    }
-
-    /* Error display */
-    .video-js .vjs-error-display {
-      background: rgba(0, 0, 0, 0.8);
-      backdrop-filter: blur(8px);
-      color: #fff;
-      border-radius: 8px;
-      margin: 20px;
-      padding: 20px;
-      font-size: 16px;
-      text-align: center;
-    }
-
-    /* Poster image */
-    .video-js .vjs-poster {
-      background-size: cover;
-      background-position: center;
-      border-radius: 12px;
-    }
-
-    /* Menu styling (quality, captions, etc.) */
-    .video-js .vjs-menu-button-popup .vjs-menu {
-      position: absolute;
-      bottom: 100%;
-      margin-bottom: 8px;
-    }
-
-    .video-js .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
-      background: rgba(0, 0, 0, 0.9);
-      backdrop-filter: blur(12px);
-      border: 1px solid rgba(255, 255, 255, 0.1);
-      border-radius: 8px;
-      min-width: 120px;
-      max-height: 200px;
-      overflow-y: auto;
-      padding: 4px 0;
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
-    }
-
-    .video-js .vjs-menu li {
-      color: rgba(255, 255, 255, 0.9);
-      padding: 8px 16px;
-      font-size: 13px;
-      cursor: pointer;
-      transition: background 0.2s ease;
-    }
-
-    .video-js .vjs-menu li:hover,
-    .video-js .vjs-menu li:focus {
-      background: rgba(255, 255, 255, 0.1);
-      color: #fff;
-    }
-
-    .video-js .vjs-menu li.vjs-selected {
-      background: var(--btfw-color-accent, #6d4df6);
-      color: #fff;
-    }
-
-    /* Text tracks / subtitles */
-    .video-js .vjs-text-track-display {
-      font-family: var(--btfw-theme-font-family, 'Inter', sans-serif);
-      font-size: 16px;
-      font-weight: 500;
-      text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.8);
-      bottom: 60px;
-    }
-
-    /* Mobile optimizations */
-    @media (max-width: 768px) {
-      .video-js .vjs-control-bar {
-        height: 44px;
-        padding: 0 8px;
-      }
-
-      .video-js .vjs-button {
-        width: 32px;
-        height: 32px;
-        margin: 0 2px;
-      }
-
-      .video-js .vjs-play-control {
-        width: 36px;
-        height: 36px;
-      }
-
-      .video-js .vjs-big-play-button {
-        width: 64px;
-        height: 64px;
-        font-size: 20px;
-      }
-
-      .video-js .vjs-current-time,
-      .video-js .vjs-duration {
-        font-size: 11px;
-        margin: 0 2px;
-      }
-    }
-
-    /* Hide unwanted controls */
-    .video-js .vjs-remaining-time { display: none !important; }
-    .video-js .vjs-picture-in-picture-control { display: none !important; }
-  `;
-
-  function applyPlayerTheme() {
-    if (document.getElementById(THEME_ID)) return;
-    const style = document.createElement("style");
-    style.id = THEME_ID;
-    style.type = "text/css";
-    style.appendChild(document.createTextNode(videoPlayerThemeCSS));
-    document.head.appendChild(style);
-  }
-
-  /* ===== Guard: block context menu + surface click-to-pause ===== */
-  const GUARD_MARK = "_btfwGuarded";
-
-  function shouldAllowClick(target) {
-    // Allow clicks on any control UI
-    if (target.closest(".vjs-control-bar,.vjs-control,.vjs-menu,.vjs-menu-content,.vjs-slider,.vjs-volume-panel")) {
-      return true;
-    }
-    return false;
-  }
-
-  function attachGuardsTo(el) {
-    if (!el || el[GUARD_MARK]) return;
-    el[GUARD_MARK] = true;
-
-    // No right-click menu
-    el.addEventListener("contextmenu", (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      return false;
-    }, true);
-
-    // Block surface left-click (capture) so Video.js doesn't toggle pause
-    const block = (e) => {
-      // Only block direct video surface / poster / spinner, not controls
-      if (shouldAllowClick(e.target)) return;
-      // Only block primary button
-      if (e.type === "click" && e.button !== 0) return;
-      e.preventDefault();
-      e.stopImmediatePropagation();
-    };
-    el.addEventListener("click", block, true);
-    el.addEventListener("pointerdown", (e)=> { if (!shouldAllowClick(e.target) && e.button===0) e.preventDefault(); }, true);
-    el.addEventListener("touchstart", block, true);
-  }
-
-  function attachGuards() {
-    // CyTube container + Video.js root + tech element
-    const candidates = [
-      ...document.querySelectorAll("#ytapiplayer"),
-      ...document.querySelectorAll(".video-js"),
-      ...document.querySelectorAll(".video-js .vjs-tech"),
-      ...document.querySelectorAll(".video-js .vjs-poster"),
-      ...document.querySelectorAll(".video-js .vjs-loading-spinner")
-    ];
-    candidates.forEach(attachGuardsTo);
-  }
-
-  /* ===== Observe player mount/reloads ===== */
-  let mo = null;
-  function watchPlayerMount() {
-    const target = document.getElementById("videowrap") || document.body;
-    if (mo) { try { mo.disconnect(); } catch(_){} mo = null; }
-    mo = new MutationObserver(() => {
-      // Each mutation pass: ensure theme + guards
-      applyPlayerTheme();
-      attachGuards();
-    });
-    mo.observe(target, { childList: true, subtree: true });
-  }
-
-  function boot() {
-    applyPlayerTheme();
-    attachGuards();
-    watchPlayerMount();
-  }
-
-  // Boot on ready and when layout signals ready
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", boot);
-  } else {
-    boot();
-  }
-  document.addEventListener("btfw:layoutReady", () => setTimeout(boot, 0));
-
-  return {
-    name: "feature:player",
-    applyTheme: applyPlayerTheme,
+    applyTheme: ensureTheme,
     attachGuards
   };
 });

--- a/modules/feature-stack.js
+++ b/modules/feature-stack.js
@@ -169,6 +169,31 @@ BTFW.define("feature:stack", ["feature:layout"], async ({}) => {
     panel._btfwToggle = toggle;
     panel._btfwSetActive = setActive;
 
+    const wireLegacyTriggers = () => {
+      const triggers = [
+        { id: "showsearch", target: "searchcontrol" },
+        { id: "showcustomembed", target: "customembed" }
+      ];
+
+      triggers.forEach(({ id, target }) => {
+        const btn = document.getElementById(id);
+        if (!btn) return;
+        if (btn.dataset.btfwAddmedia === target) return;
+
+        btn.dataset.btfwAddmedia = target;
+        btn.setAttribute("aria-controls", "btfw-addmedia-panel");
+        btn.addEventListener("click", (ev) => {
+          ev.preventDefault();
+          ev.stopPropagation();
+          setActive(target);
+          toggle(true);
+          btn.blur();
+        });
+      });
+    };
+
+    wireLegacyTriggers();
+
     return { panel, toggle, setActive };
   }
 
@@ -525,13 +550,23 @@ BTFW.define("feature:stack", ["feature:layout"], async ({}) => {
     } 
   }
   
-  function attachFooter(footer){ 
-    const real=document.getElementById("footer")||document.querySelector("footer"); 
-    if(real && !footer.contains(real)){ 
-      real.classList.add("btfw-footer"); 
-      footer.innerHTML=""; 
-      footer.appendChild(real); 
-    } 
+  function attachFooter(footer){
+    if (!footer) return;
+    if (footer.querySelector("#btfw-footer")) return;
+
+    const themed = document.getElementById("btfw-footer");
+    if (themed && themed !== footer && !footer.contains(themed)) {
+      footer.innerHTML = "";
+      footer.appendChild(themed);
+      return;
+    }
+
+    const real=document.getElementById("footer")||document.querySelector("footer");
+    if(real && !footer.contains(real)){
+      real.classList.add("btfw-footer");
+      footer.innerHTML="";
+      footer.appendChild(real);
+    }
   }
 
   function movePollButton() {


### PR DESCRIPTION
## Summary
- ensure the custom Video.js theme stays applied by stripping legacy skin classes and re-appending our stylesheet
- always mount the BillTube footer inside the stack footer, wiring legacy add media buttons into the new panel flow
- tighten responsive UI: refine chat message layout/timestamps, cap popover widths to chat size, and shrink the navbar/grid in vertical mode

## Testing
- No automated tests were run (CSS/JS changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d5b44313e48329aa6c82be11e152ac