### PR TITLE
Refine notifications, stack controls, and player styling

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -391,6 +391,19 @@ a:hover {
   gap: var(--btfw-gap);
   margin-top: var(--btfw-gap);
   flex: 1;
+  padding-inline: 0;
+  transition: padding 0.24s ease, gap 0.24s ease;
+}
+.btfw-stack-list--compact{
+  gap: calc(var(--btfw-gap) + 6px);
+}
+body:not(.btfw-mobile-stack-enabled) #btfw-stack .btfw-stack-list.btfw-stack-list--compact{
+  padding-inline: clamp(16px, 4vw, 52px);
+}
+body:not(.btfw-mobile-stack-enabled) #btfw-stack.btfw-stack--compact .btfw-stack-item{
+  border-radius: calc(var(--btfw-radius) + 6px);
+  box-shadow: 0 20px 48px color-mix(in srgb, var(--btfw-color-bg) 48%, transparent 52%);
+  border-color: color-mix(in srgb, var(--btfw-border) 68%, transparent 32%);
 }
 .btfw-stack-item{
   border:1px solid var(--btfw-border);
@@ -1016,6 +1029,60 @@ a:hover {
   gap: 14px;
 }
 
+#btfw-theme-modal .btfw-compact-stack-btn{
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--btfw-border) 70%, transparent 30%);
+  background: color-mix(in srgb, var(--btfw-color-panel) 88%, transparent 12%);
+  color: color-mix(in srgb, var(--btfw-color-text) 90%, transparent 10%);
+  font-weight: 600;
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
+}
+
+#btfw-theme-modal .btfw-compact-stack-btn .btfw-compact-stack-label{
+  font-size: 0.85rem;
+  text-transform: none;
+  letter-spacing: 0.02em;
+}
+
+#btfw-theme-modal .btfw-compact-stack-btn .btfw-compact-stack-status{
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--btfw-color-panel) 76%, transparent 24%);
+  color: color-mix(in srgb, var(--btfw-color-text) 72%, transparent 28%);
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+#btfw-theme-modal .btfw-compact-stack-btn[aria-pressed="true"]{
+  background: var(--btfw-navbar-pill-bg);
+  border-color: color-mix(in srgb, var(--btfw-color-accent) 40%, transparent 60%);
+  color: var(--btfw-navbar-pill-text);
+  box-shadow: 0 18px 42px color-mix(in srgb, var(--btfw-color-accent) 32%, transparent 68%);
+}
+
+#btfw-theme-modal .btfw-compact-stack-btn[aria-pressed="true"] .btfw-compact-stack-status{
+  background: var(--btfw-color-accent);
+  color: var(--btfw-color-on-accent);
+}
+
+#btfw-theme-modal .btfw-compact-stack-btn:focus-visible{
+  outline: 2px solid color-mix(in srgb, var(--btfw-color-accent) 65%, transparent 35%);
+  outline-offset: 3px;
+}
+
 #btfw-theme-modal .btfw-ts-control{
   display: flex;
   flex-direction: column;
@@ -1168,4 +1235,7 @@ a:hover {
 }
 #btfw-grid.btfw-loaded {
   opacity: 1;
+}
+#showmediaurl{
+  display: none !important;
 }

--- a/css/chat.css
+++ b/css/chat.css
@@ -26,6 +26,11 @@
   flex-shrink: 0; /* Don't shrink these bars */
 }
 
+#chatwrap .btfw-chat-topbar{
+  position: relative;
+  overflow: visible;
+}
+
 .btfw-chat-topbar-left{
   display:flex;
   align-items:center;

--- a/css/overlays.css
+++ b/css/overlays.css
@@ -150,9 +150,10 @@
   justify-content: center;
 }
 #videowrap.btfw-pip {
-  border-radius: var(--btfw-radius);
+  border-radius: 18px;
   overflow: hidden;
-  box-shadow: 0 10px 30px color-mix(in srgb, var(--btfw-color-bg) 54%, transparent 46%);
+  border: 1px solid color-mix(in srgb, var(--btfw-border) 70%, transparent 30%);
+  box-shadow: 0 22px 48px color-mix(in srgb, var(--btfw-color-bg) 46%, transparent 54%);
 }
 
 /* ======================================================================
@@ -708,16 +709,36 @@ html[data-btfw-theme="dark"] .panel {
 
 #btfw-notify-stack{
   position: absolute;
-  top: 12px;
-  right: 12px;
-  left: auto;
   z-index: 4200;
   display: flex;
   flex-direction: column;
   gap: 12px;
   align-items: flex-end;
   pointer-events: none;
+  right: 12px;
+  left: auto;
+  top: calc(100% + 12px);
+  width: min(360px, 100%);
+  max-width: calc(100vw - 32px);
+}
+
+#btfw-notify-stack.btfw-notify-stack--buffer{
+  top: 12px;
   width: min(360px, calc(100% - 24px));
+}
+
+#chatwrap .btfw-chat-topbar > #btfw-notify-stack{
+  transform-origin: top right;
+}
+
+@media (max-width: 720px){
+  #chatwrap .btfw-chat-topbar > #btfw-notify-stack{
+    right: 8px;
+    left: 8px;
+    width: auto;
+    max-width: none;
+    align-items: stretch;
+  }
 }
 
 .btfw-notice{

--- a/css/player.css
+++ b/css/player.css
@@ -7,18 +7,52 @@
   width: 100%;
   min-width: 0;
   position: relative; /* anchor overlay chrome */
+  display: grid;
+  place-items: stretch;
+  aspect-ratio: var(--btfw-video-aspect, 16 / 9);
+  background: color-mix(in srgb, var(--btfw-video-bg) 88%, transparent 12%);
+  border-radius: 24px;
+  border: 1px solid color-mix(in srgb, var(--btfw-border) 68%, transparent 32%);
+  box-shadow: 0 32px 62px color-mix(in srgb, var(--btfw-color-bg) 52%, transparent 48%);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+#videowrap::after{
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(180deg,
+    color-mix(in srgb, var(--btfw-video-bg) 40%, transparent 60%) 0%,
+    transparent 35%,
+    transparent 65%,
+    color-mix(in srgb, var(--btfw-video-bg) 22%, transparent 78%) 100%
+  );
+  mix-blend-mode: screen;
+  opacity: 0.18;
+  transition: opacity 0.24s ease;
+}
+
+#videowrap:hover::after{
+  opacity: 0.32;
+}
+
+#videowrap > *{
+  grid-area: 1 / 1;
+  width: 100%;
+  height: 100%;
 }
 
 /* Support legacy .embed-responsive wrappers if present */
 #videowrap .embed-responsive{
   position: relative;
   width: 100%;
-  height: auto;
+  height: 100%;
   display: block;
   overflow: hidden;
-  aspect-ratio: var(--btfw-video-aspect, 16 / 9);
   background: var(--btfw-video-bg);
-  border-radius: var(--btfw-radius);
+  border-radius: inherit;
 }
 #videowrap .embed-responsive::before{
   content: "";
@@ -39,22 +73,36 @@
   height: 100%;
   display: block;
   border: 0;
+  border-radius: inherit;
 }
 
 /* If no wrapper, modern browsers can use aspect-ratio on iframe */
 #videowrap iframe,
 #videowrap video{
   width: 100%;
-  height: auto;
-  aspect-ratio: var(--btfw-video-aspect, 16 / 9);
+  height: 100%;
+  aspect-ratio: auto;
   border: 0;
   display: block;
   background: var(--btfw-video-bg);
-  border-radius: var(--btfw-radius);
+  border-radius: inherit;
+  object-fit: contain;
+}
+
+#videowrap #ytapiplayer,
+#videowrap .video-js,
+#videowrap .jwplayer,
+#videowrap .flowplayer{
+  width: 100% !important;
+  height: 100% !important;
+  border-radius: inherit;
 }
 
 /* Video overlay buttons are styled in overlays.css; ensure interactivity */
-#videowrap .btfw-video-overlay{ pointer-events: none; }
+#videowrap .btfw-video-overlay{
+  pointer-events: none;
+  grid-area: 1 / 1;
+}
 #videowrap .btfw-video-overlay .btfw-vo-right{ pointer-events: auto; }
 
 /* Space for modules stacked under the player */
@@ -166,6 +214,13 @@
 .queue_entry .btn-group .btn i.fa {
   margin-right: 4px;
   opacity: 0.85;
+}
+
+@media (max-width: 768px){
+  #videowrap{
+    border-radius: 18px;
+    box-shadow: 0 26px 48px color-mix(in srgb, var(--btfw-color-bg) 46%, transparent 54%);
+  }
 }
 
 #queue li.queue_entry.queue_active,

--- a/modules/feature-notify.js
+++ b/modules/feature-notify.js
@@ -16,9 +16,8 @@ BTFW.define("feature:notify", [], async () => {
     const buf = $("#messagebuffer");
     if (!buf) return null;
 
-    // make sure the buffer is a positioning context for our absolute overlay
-    const cs = getComputedStyle(buf);
-    if (cs.position === "static") buf.style.position = "relative";
+    const chatWrap = $("#chatwrap");
+    const topbar = chatWrap?.querySelector(".btfw-chat-topbar");
 
     let stack = $("#btfw-notify-stack");
     if (!stack) {
@@ -29,11 +28,22 @@ BTFW.define("feature:notify", [], async () => {
       stack.setAttribute("aria-relevant", "additions");
     }
 
-    if (stack.parentElement !== buf) buf.appendChild(stack);
+    const inTopbar = !!topbar;
 
-    const first = buf.firstElementChild;
-    if (first && first !== stack) {
-      buf.insertBefore(stack, first);
+    stack.classList.toggle("btfw-notify-stack--topbar", inTopbar);
+    stack.classList.toggle("btfw-notify-stack--buffer", !inTopbar);
+
+    if (inTopbar) {
+      if (getComputedStyle(topbar).position === "static") {
+        topbar.style.position = "relative";
+      }
+      if (stack.parentElement !== topbar) topbar.appendChild(stack);
+    } else {
+      const cs = getComputedStyle(buf);
+      if (cs.position === "static") buf.style.position = "relative";
+      if (stack.parentElement !== buf) buf.appendChild(stack);
+      const first = buf.firstElementChild;
+      if (first && first !== stack) buf.insertBefore(stack, first);
     }
 
     return stack;


### PR DESCRIPTION
## Summary
- anchor chat notifications to the chat topbar and update toast styles so alerts float without shifting messages
- replace the Appearance settings with a default-on desktop "Compact stack" toggle, remove the PiP toggle, and hide unused controls
- refresh the video player container styling for a cleaner look that fits the new layout polish

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6ed54e1c48329b2227d9c0d680330