### PR TITLE
Improve layout of add media buttons

### DIFF
--- a/css/player.css
+++ b/css/player.css
@@ -400,12 +400,15 @@
 
 .btfw-addmedia-panel .input-group {
   display: flex;
+  flex-wrap: nowrap;
   align-items: stretch;
-  gap: 10px;
+  gap: 12px;
+  width: 100%;
 }
 
 .btfw-addmedia-panel .input-group .form-control {
-  flex: 1 1 auto;
+  flex: 1 1 240px;
+  min-width: 0;
   border-radius: 14px;
   border: 1px solid color-mix(in srgb, var(--btfw-color-accent) 28%, transparent 72%);
   background: color-mix(in srgb, var(--btfw-color-surface) 90%, transparent 10%);
@@ -421,9 +424,16 @@
 
 .btfw-addmedia-panel .input-group-btn {
   display: flex;
+  position: static;
+  align-items: stretch;
+  justify-content: center;
+  flex: 0 0 auto;
+  white-space: normal;
+  font-size: inherit;
 }
 
 .btfw-addmedia-panel .input-group-btn .btn {
+  flex: 0 0 auto;
   border-radius: 12px;
   border: 0;
   background: linear-gradient(140deg,
@@ -434,6 +444,23 @@
   padding: 10px 16px;
   box-shadow: 0 12px 28px color-mix(in srgb, var(--btfw-color-accent) 30%, transparent 70%);
   transition: transform 0.16s ease, filter 0.16s ease;
+  white-space: nowrap;
+}
+
+@media (max-width: 680px) {
+  .btfw-addmedia-panel .input-group {
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+
+  .btfw-addmedia-panel .input-group-btn {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .btfw-addmedia-panel .input-group-btn .btn {
+    width: 100%;
+  }
 }
 
 .btfw-addmedia-panel .input-group-btn .btn:hover {


### PR DESCRIPTION
## Summary
- replace the add media input group layout with a flexible row so both action buttons stay visible
- allow the controls to wrap cleanly on narrow viewports while keeping their styling consistent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d82a3eef68832992396f0f46117476