### PR TITLE
style: refine VideoJS theme and re-enable menus

### DIFF
--- a/css/player.css
+++ b/css/player.css
@@ -93,6 +93,340 @@
   border-radius: inherit;
 }
 
+/* ===== Video.js streamlined theme ===== */
+#videowrap .video-js.btfw-videojs-themed{
+  --btfw-vjs-surface: color-mix(in srgb, var(--btfw-color-bg) 88%, transparent 12%);
+  --btfw-vjs-surface-strong: color-mix(in srgb, var(--btfw-color-panel) 92%, transparent 8%);
+  --btfw-vjs-text-muted: color-mix(in srgb, var(--btfw-color-text) 68%, transparent 32%);
+  --btfw-vjs-text-strong: color-mix(in srgb, var(--btfw-color-text) 96%, white 4%);
+  --btfw-vjs-accent: color-mix(in srgb, var(--btfw-color-accent) 90%, white 10%);
+  --btfw-vjs-accent-soft: color-mix(in srgb, var(--btfw-color-accent) 28%, transparent 72%);
+  font-family: var(--btfw-font-body);
+  color: var(--btfw-vjs-text-strong);
+  background: radial-gradient(circle at 18% 18%,
+      color-mix(in srgb, var(--btfw-color-bg) 62%, transparent 38%),
+      color-mix(in srgb, var(--btfw-color-bg) 96%, black 4%) 68%);
+  border-radius: inherit;
+  overflow: hidden;
+  font-size: 10px;
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-tech,
+#videowrap .video-js.btfw-videojs-themed video,
+#videowrap .video-js.btfw-videojs-themed iframe{
+  border-radius: inherit;
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-loading-spinner{
+  border-color: var(--btfw-vjs-accent-soft);
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-big-play-button{
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 84px;
+  height: 84px;
+  border-radius: 22px;
+  background: color-mix(in srgb, var(--btfw-color-bg) 30%, black 70%);
+  border: 1px solid color-mix(in srgb, var(--btfw-color-accent) 26%, transparent 74%);
+  box-shadow: 0 16px 34px color-mix(in srgb, var(--btfw-color-bg) 56%, transparent 44%),
+    0 6px 16px color-mix(in srgb, black 20%, transparent 80%);
+  display: grid;
+  place-items: center;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-big-play-button .vjs-icon-placeholder:before{
+  font-size: 40px;
+  line-height: 1;
+  margin-left: 4px;
+  color: var(--btfw-vjs-text-strong);
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-big-play-button:hover{
+  background: color-mix(in srgb, var(--btfw-color-bg) 18%, black 82%);
+  transform: translate(-50%, -50%) scale(1.02);
+  box-shadow: 0 20px 40px color-mix(in srgb, var(--btfw-color-bg) 62%, transparent 38%),
+    0 8px 20px color-mix(in srgb, black 24%, transparent 76%);
+}
+
+#videowrap .video-js.btfw-videojs-themed.vjs-has-started .vjs-big-play-button{
+  display: none;
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-control-bar{
+  position: absolute;
+  inset-inline: clamp(12px, 4vw, 26px);
+  bottom: clamp(12px, 3vw, 28px);
+  display: flex;
+  align-items: center;
+  gap: clamp(10px, 2.5vw, 18px);
+  padding: clamp(10px, 1.6vw, 16px) clamp(14px, 2.6vw, 20px);
+  border-radius: clamp(14px, 2vw, 18px);
+  background: linear-gradient(135deg,
+      color-mix(in srgb, var(--btfw-vjs-surface) 86%, transparent 14%),
+      color-mix(in srgb, var(--btfw-vjs-surface-strong) 92%, transparent 8%));
+  border: 1px solid color-mix(in srgb, var(--btfw-color-accent) 26%, transparent 74%);
+  box-shadow: 0 18px 40px color-mix(in srgb, var(--btfw-color-bg) 48%, transparent 52%),
+    0 8px 20px color-mix(in srgb, black 20%, transparent 80%);
+  backdrop-filter: blur(18px);
+  transition: opacity 0.2s ease, transform 0.24s ease;
+  pointer-events: auto;
+}
+
+@supports not ((-webkit-backdrop-filter: blur(0)) or (backdrop-filter: blur(0))){
+  #videowrap .video-js.btfw-videojs-themed .vjs-control-bar{
+    background: color-mix(in srgb, var(--btfw-vjs-surface-strong) 96%, transparent 4%);
+  }
+}
+
+#videowrap .video-js.btfw-videojs-themed.vjs-has-started.vjs-user-inactive:not(.vjs-seeking):not(.vjs-paused) .vjs-control-bar{
+  opacity: 0;
+  transform: translateY(12px);
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-control{
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  color: var(--btfw-vjs-text-muted);
+  transition: color 0.16s ease, background 0.16s ease, transform 0.16s ease, box-shadow 0.16s ease;
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-control:focus-visible{
+  outline: 2px solid color-mix(in srgb, var(--btfw-color-accent) 56%, transparent 44%);
+  outline-offset: 4px;
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-button{
+  width: clamp(34px, 4.6vw, 40px);
+  height: clamp(34px, 4.6vw, 40px);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--btfw-vjs-surface-strong) 86%, transparent 14%);
+  border: 1px solid color-mix(in srgb, var(--btfw-color-accent) 18%, transparent 82%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: inset 0 0 0 0 transparent;
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-button:not(.vjs-play-control):hover{
+  color: var(--btfw-vjs-text-strong);
+  background: color-mix(in srgb, var(--btfw-vjs-surface-strong) 94%, transparent 6%);
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px color-mix(in srgb, var(--btfw-color-bg) 40%, transparent 60%);
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-play-control{
+  width: clamp(38px, 5vw, 44px);
+  height: clamp(38px, 5vw, 44px);
+  border-radius: 14px;
+  background: linear-gradient(145deg,
+      color-mix(in srgb, var(--btfw-color-accent) 92%, white 8%),
+      color-mix(in srgb, var(--btfw-color-accent) 58%, transparent 42%));
+  border: 0;
+  color: color-mix(in srgb, var(--btfw-color-text) 98%, white 2%);
+  box-shadow: 0 12px 28px color-mix(in srgb, var(--btfw-color-accent) 32%, transparent 68%),
+    0 6px 16px color-mix(in srgb, black 22%, transparent 78%);
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-play-control:hover{
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px color-mix(in srgb, var(--btfw-color-accent) 44%, transparent 56%),
+    0 8px 18px color-mix(in srgb, black 26%, transparent 74%);
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-current-time,
+#videowrap .video-js.btfw-videojs-themed .vjs-duration,
+#videowrap .video-js.btfw-videojs-themed .vjs-remaining-time{
+  font-size: clamp(11px, 1.5vw, 13px);
+  font-weight: 600;
+  color: var(--btfw-vjs-text-muted);
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-time-divider{
+  color: color-mix(in srgb, var(--btfw-vjs-text-muted) 92%, transparent 8%);
+  font-size: clamp(11px, 1.4vw, 13px);
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-progress-control{
+  flex: 1 1 auto;
+  min-width: 140px;
+  display: flex;
+  align-items: center;
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-progress-control .vjs-progress-holder{
+  flex: 1;
+  height: clamp(4px, 0.9vw, 6px);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--btfw-vjs-surface-strong) 78%, transparent 22%);
+  border: 1px solid color-mix(in srgb, var(--btfw-color-accent) 18%, transparent 82%);
+  overflow: visible;
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-progress-control:hover .vjs-progress-holder{
+  background: color-mix(in srgb, var(--btfw-vjs-surface-strong) 88%, transparent 12%);
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-play-progress{
+  background: linear-gradient(90deg,
+      color-mix(in srgb, var(--btfw-color-accent) 96%, white 4%),
+      color-mix(in srgb, var(--btfw-color-accent) 64%, transparent 36%));
+  border-radius: inherit;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--btfw-color-accent) 42%, transparent 58%),
+    0 0 14px color-mix(in srgb, var(--btfw-color-accent) 24%, transparent 76%);
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-load-progress{
+  background: color-mix(in srgb, var(--btfw-vjs-accent-soft) 36%, transparent 64%);
+  border-radius: inherit;
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-progress-control .vjs-mouse-display{
+  display: none;
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-progress-control .vjs-time-tooltip{
+  background: color-mix(in srgb, var(--btfw-color-bg) 92%, transparent 8%);
+  border-radius: 8px;
+  font-size: 12px;
+  color: var(--btfw-vjs-text-strong);
+  border: 1px solid color-mix(in srgb, var(--btfw-color-accent) 24%, transparent 76%);
+  padding: 4px 8px;
+  box-shadow: 0 8px 18px color-mix(in srgb, var(--btfw-color-bg) 46%, transparent 54%);
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-slider-bar{
+  background: transparent;
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-progress-holder .vjs-slider-bar::after{
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 100%;
+  width: 14px;
+  height: 14px;
+  transform: translate(-50%, -50%);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--btfw-color-accent) 94%, white 6%);
+  box-shadow: 0 6px 16px color-mix(in srgb, var(--btfw-color-accent) 42%, transparent 58%);
+  transition: box-shadow 0.16s ease;
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-progress-control:hover .vjs-progress-holder .vjs-slider-bar::after{
+  box-shadow: 0 8px 20px color-mix(in srgb, var(--btfw-color-accent) 52%, transparent 48%);
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-volume-panel{
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-volume-bar{
+  width: clamp(80px, 14vw, 120px);
+  height: 4px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--btfw-vjs-surface-strong) 74%, transparent 26%);
+  border: 1px solid color-mix(in srgb, var(--btfw-color-accent) 18%, transparent 82%);
+  overflow: visible;
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-volume-level{
+  background: linear-gradient(90deg,
+      color-mix(in srgb, var(--btfw-color-accent) 92%, white 8%),
+      color-mix(in srgb, var(--btfw-color-accent) 58%, transparent 42%));
+  border-radius: inherit;
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-volume-level::after{
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 100%;
+  width: 12px;
+  height: 12px;
+  transform: translate(-50%, -50%);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--btfw-color-accent) 94%, white 6%);
+  box-shadow: 0 6px 16px color-mix(in srgb, var(--btfw-color-accent) 42%, transparent 58%);
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-volume-panel.vjs-mute-toggle-only .vjs-volume-control{
+  display: none;
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-menu-button-popup .vjs-menu{
+  background: color-mix(in srgb, var(--btfw-vjs-surface-strong) 96%, transparent 4%);
+  border-radius: 12px;
+  border: 1px solid color-mix(in srgb, var(--btfw-color-accent) 22%, transparent 78%);
+  box-shadow: 0 14px 32px color-mix(in srgb, var(--btfw-color-bg) 48%, transparent 52%);
+  padding: 6px 0;
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-menu-button-popup .vjs-menu-item{
+  font-size: 13px;
+  color: var(--btfw-vjs-text-muted);
+  padding: 8px 18px;
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-menu-button-popup .vjs-menu-item.vjs-selected,
+#videowrap .video-js.btfw-videojs-themed .vjs-menu-button-popup .vjs-menu-item:focus,
+#videowrap .video-js.btfw-videojs-themed .vjs-menu-button-popup .vjs-menu-item:hover{
+  background: color-mix(in srgb, var(--btfw-color-accent) 24%, transparent 76%);
+  color: var(--btfw-vjs-text-strong);
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-menu li.vjs-menu-title{
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--btfw-vjs-text-muted);
+  padding: 8px 18px 4px;
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-live-control,
+#videowrap .video-js.btfw-videojs-themed .vjs-live-control .vjs-live-display{
+  font-size: 11px;
+  color: var(--btfw-vjs-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+#videowrap .video-js.btfw-videojs-themed .vjs-live-control::before{
+  content: "";
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  margin-right: 8px;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--btfw-color-accent) 78%, transparent 22%);
+  box-shadow: 0 0 0 6px color-mix(in srgb, var(--btfw-color-accent) 22%, transparent 78%);
+}
+
+@media (max-width: 720px){
+  #videowrap .video-js.btfw-videojs-themed .vjs-control-bar{
+    inset-inline: clamp(8px, 4vw, 18px);
+    padding: clamp(10px, 3.8vw, 18px);
+    flex-wrap: wrap;
+    row-gap: 10px;
+  }
+
+  #videowrap .video-js.btfw-videojs-themed .vjs-progress-control{
+    order: 4;
+    flex-basis: 100%;
+  }
+
+  #videowrap .video-js.btfw-videojs-themed .vjs-volume-panel{
+    flex: 1 1 auto;
+    justify-content: flex-end;
+  }
+}
+
 /* Video overlay buttons are styled in overlays.css; ensure interactivity */
 #videowrap .btfw-video-overlay{
   pointer-events: none;

--- a/modules/feature-player.js
+++ b/modules/feature-player.js
@@ -1,17 +1,43 @@
-/* BTFW — feature:player (restore default VideoJS look and apply tech guards) */
+/* BTFW — feature:player (streamlined VideoJS look + tech guards) */
 BTFW.define("feature:player", ["feature:layout"], async ({}) => {
-  const THEME_ID = "btfw-videojs-streamlined-theme";
   const CUSTOM_THEME_CLASS = "btfw-videojs-themed";
   const DEFAULT_SKIN_CLASS = "vjs-default-skin";
+  const DEFAULT_STYLES_LINK_ID = "btfw-videojs-default-css";
+  const DEFAULT_STYLES_URL = "https://vjs.zencdn.net/7.20.3/video-js.css";
 
-  function removeCustomThemeStyle() {
-    const style = document.getElementById(THEME_ID);
-    if (style && style.parentNode) {
-      style.parentNode.removeChild(style);
-    }
+  function ensureDefaultStylesheet() {
+    const doc = document;
+    if (!doc || !doc.head) return;
+    if (doc.getElementById(DEFAULT_STYLES_LINK_ID)) return;
+
+    const existing = doc.querySelector(
+      'link[href*="video-js"], link[href*="videojs"], style[data-vjs-styles]' 
+    );
+    if (existing) return;
+
+    const link = doc.createElement("link");
+    link.id = DEFAULT_STYLES_LINK_ID;
+    link.rel = "stylesheet";
+    link.href = DEFAULT_STYLES_URL;
+    doc.head.appendChild(link);
   }
 
-  function applyDefaultSkin() {
+  function defaultSkinAppearsActive() {
+    if (typeof window === "undefined" || !document.body) return false;
+    const probe = document.createElement("div");
+    probe.className = `video-js ${DEFAULT_SKIN_CLASS}`;
+    probe.style.position = "absolute";
+    probe.style.opacity = "0";
+    probe.style.pointerEvents = "none";
+    probe.style.width = "1px";
+    probe.style.height = "1px";
+    document.body.appendChild(probe);
+    const fontSize = window.getComputedStyle(probe).fontSize;
+    probe.remove();
+    return fontSize && Math.abs(parseFloat(fontSize) - 10) < 0.2;
+  }
+
+  function ensureDefaultSkin() {
     document.querySelectorAll(".video-js").forEach((player) => {
       player.classList.remove(CUSTOM_THEME_CLASS);
       if (!player.classList.contains(DEFAULT_SKIN_CLASS)) {
@@ -20,9 +46,16 @@ BTFW.define("feature:player", ["feature:layout"], async ({}) => {
     });
   }
 
-  function applyDefaultTheme() {
-    removeCustomThemeStyle();
-    applyDefaultSkin();
+  function applyStreamlinedTheme() {
+    if (!defaultSkinAppearsActive()) {
+      ensureDefaultStylesheet();
+    }
+    ensureDefaultSkin();
+    document.querySelectorAll(".video-js").forEach((player) => {
+      if (!player.classList.contains(CUSTOM_THEME_CLASS)) {
+        player.classList.add(CUSTOM_THEME_CLASS);
+      }
+    });
   }
 
   /* ===== Guard: block context menu + surface click-to-pause ===== */
@@ -39,12 +72,6 @@ BTFW.define("feature:player", ["feature:layout"], async ({}) => {
   function attachGuardsTo(el) {
     if (!el || el[GUARD_MARK]) return;
     el[GUARD_MARK] = true;
-
-    el.addEventListener("contextmenu", (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      return false;
-    }, true);
 
     const block = (e) => {
       if (shouldAllowClick(e.target)) return;
@@ -78,7 +105,7 @@ BTFW.define("feature:player", ["feature:layout"], async ({}) => {
       try { watchPlayerMount._mo.disconnect(); } catch (_) {}
     }
     const mo = new MutationObserver(() => {
-      applyDefaultTheme();
+      applyStreamlinedTheme();
       attachGuards();
     });
     mo.observe(target, { childList: true, subtree: true });
@@ -88,13 +115,17 @@ BTFW.define("feature:player", ["feature:layout"], async ({}) => {
   function watchHead() {
     const head = document.head;
     if (!head || watchHead._mo) return;
-    const mo = new MutationObserver(() => removeCustomThemeStyle());
+    const mo = new MutationObserver(() => {
+      if (!defaultSkinAppearsActive()) {
+        ensureDefaultStylesheet();
+      }
+    });
     mo.observe(head, { childList: true });
     watchHead._mo = mo;
   }
 
   function boot() {
-    applyDefaultTheme();
+    applyStreamlinedTheme();
     attachGuards();
     watchPlayerMount();
     watchHead();
@@ -110,7 +141,7 @@ BTFW.define("feature:player", ["feature:layout"], async ({}) => {
 
   return {
     name: "feature:player",
-    applyDefaultTheme,
+    applyStreamlinedTheme,
     attachGuards
   };
 });


### PR DESCRIPTION
## Summary
- reshape the VideoJS control bar, play button, and sliders to match the requested slim amber look while preserving the glass wrapper
- retune progress, volume, tooltip, and menu treatments so text stays legible on Cytube’s dark palette
- stop canceling contextmenu events in the player guard so right-click and VideoJS menus work again

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d83dd51f688329987ea6b9978d1469