### PR TITLE
Refine chat action bar layout

### DIFF
--- a/css/chat.css
+++ b/css/chat.css
@@ -127,6 +127,10 @@
   align-items: center;
 }
 
+#messagebuffer > div.btfw-has-avatar span.timestamp + span + span {
+  margin-top: 10px;
+}
+
 #messagebuffer > div span .username,
 #messagebuffer > div span .nick,
 #messagebuffer > div span .name {
@@ -213,6 +217,9 @@
   padding-top:6px;
   border-top:1px solid color-mix(in srgb, var(--btfw-border) 55%, transparent 45%);
   margin-top:2px;
+}
+.btfw-chat-actions #usercount{
+  margin-left:auto;
 }
 .button.btfw-chatbtn{ display:inline-flex; align-items:center; gap:6px; }
 
@@ -711,20 +718,15 @@ body.btfw-ts-hide #messagebuffer .timestamp { display:none !important; }
   background: var(--btfw-chip-bg-hover);
 }
 
-/* Chat bottom bar split: composer (top) + meta (bottom-right) */
-.btfw-chat-right{
+#usercount.btfw-usercount{
   display:flex;
   align-items:center;
-  gap:8px;
-  align-self:flex-end;
-  padding:0 6px;
-  color: color-mix(in srgb, var(--btfw-color-chat-text) 86%, transparent 14%);
+  gap:6px;
   font-size: 12px;
-}
-
-#usercount.btfw-usercount{
-  display:flex; align-items:center; gap:6px;
-  font-size: 12px; opacity:.9;
+  opacity:.9;
+  margin-left:auto;
+  padding-left:12px;
+  color: color-mix(in srgb, var(--btfw-color-chat-text) 86%, transparent 14%);
 }
 
 #usercount .fa-users{ font-size:14px; opacity:.75; }

--- a/modules/feature-chat-tools.js
+++ b/modules/feature-chat-tools.js
@@ -234,7 +234,10 @@ BTFW.define("feature:chat-tools", ["feature:chat"], async ({}) => {
     b.id = "btfw-chattools-btn";
     b.className = "button is-dark is-small btfw-chatbtn";
     b.innerHTML = '<span style="font-weight:700;letter-spacing:.5px;">Aa</span>';
-    actions.prepend(b);
+    const insertBefore = actions.querySelector("#btfw-chatcmds-btn")
+      || actions.querySelector("#btfw-users-toggle")
+      || actions.querySelector("#usercount");
+    actions.insertBefore(b, insertBefore || null);
   }
 
   /* ---------- History ---------- */

--- a/modules/feature-chat.js
+++ b/modules/feature-chat.js
@@ -136,14 +136,40 @@ function normalizeChatActionButtons() {
     b.id = "btfw-btn-gif";
     b.className = "button is-dark is-small btfw-chatbtn";
     b.title = "GIFs";
-    b.innerHTML = '<span class="gif-badge">GIF</span>';
+    b.innerHTML = '<i class="fa fa-file-video-o"></i>';
     actions.appendChild(b);
   }
 
   // if some other module created them elsewhere, adopt them
-  ["btfw-btn-emotes", "btfw-btn-gif", "btfw-chatcmds-btn", "btfw-users-toggle"].forEach(id=>{
+  ["btfw-btn-emotes", "btfw-btn-gif", "btfw-chatcmds-btn", "btfw-users-toggle", "usercount"].forEach(id=>{
     const el = document.getElementById(id);
     if (el && el.parentElement !== actions) actions.appendChild(el);
+  });
+
+  const gifBtn = actions.querySelector("#btfw-btn-gif");
+  if (gifBtn) {
+    gifBtn.innerHTML = '<i class="fa fa-file-video-o"></i>';
+    gifBtn.title = gifBtn.title || "GIFs";
+  }
+
+  orderChatActions(actions);
+}
+
+function orderChatActions(actions){
+  if (!actions) return;
+  const orderedSelectors = [
+    "#btfw-btn-emotes",
+    "#btfw-btn-gif",
+    "#btfw-chattools-btn",
+    "#btfw-ct-open",
+    "#btfw-chatcmds-btn",
+    "#btfw-users-toggle",
+    "#usercount"
+  ];
+
+  orderedSelectors.forEach(sel => {
+    const el = actions.querySelector(sel);
+    if (el && el.parentElement === actions) actions.appendChild(el);
   });
 }
 
@@ -628,7 +654,7 @@ function watchForStrayButtons(){
       b.id = "btfw-btn-gif";
       b.className = "button is-dark is-small btfw-chatbtn";
       b.title = "GIFs";
-      b.innerHTML = '<span class="gif-badge">GIF</span>';
+      b.innerHTML = '<i class="fa fa-file-video-o"></i>';
       actions.appendChild(b);
     }
 
@@ -673,27 +699,25 @@ function watchForStrayButtons(){
   function ensureUsercountInBar(){
     const cw  = $("#chatwrap"); if (!cw) return;
     const bar = cw.querySelector(".btfw-chat-bottombar"); if (!bar) return;
-
-    let right = bar.querySelector(".btfw-chat-right");
-    if (!right) {
-      right = document.createElement("div");
-      right.className = "btfw-chat-right";
-      bar.appendChild(right);
-    }
+    const actions = bar.querySelector("#btfw-chat-actions"); if (!actions) return;
 
     let uc = $("#usercount");
     if (!uc) uc = Object.assign(document.createElement("div"), { id:"usercount" });
     uc.classList.add("btfw-usercount");
 
-    if (!uc.querySelector(".btfw-usercount-num")) {
-      uc.innerHTML = `<i class="fa fa-users" aria-hidden="true"></i>
-                      <span class="btfw-usercount-num">0</span>`;
-    } else {
-      const num = uc.textContent.match(/\d+/);
-      uc.innerHTML = `<i class="fa fa-users" aria-hidden="true"></i>
-                      <span class="btfw-usercount-num">${num ? num[0] : "0"}</span>`;
-    }
-    right.appendChild(uc);
+    const existingText = uc.querySelector(".btfw-usercount-num")
+      ? uc.querySelector(".btfw-usercount-num").textContent
+      : uc.textContent;
+    const existingNum = (existingText && existingText.match(/\d+/))
+      ? existingText.match(/\d+/)[0]
+      : "0";
+
+    uc.innerHTML = `<i class="fa fa-users" aria-hidden="true"></i>
+                    <span class="btfw-usercount-num">${existingNum}</span>`;
+
+    if (uc.parentElement !== actions) actions.appendChild(uc);
+
+    orderChatActions(actions);
 
     const ch = $("#chatheader");
     if (ch) ch.remove();

--- a/modules/feature-gifs.js
+++ b/modules/feature-gifs.js
@@ -68,7 +68,7 @@ BTFW.define("feature:gifs", [], async () => {
         btn.id = "btfw-btn-gif";
         btn.type = "button";
         btn.className = "button is-dark is-small btfw-chatbtn btfw-btn-gif";
-        btn.innerHTML = (document.querySelector(".fa")) ? '<i class="fa fa-gif"></i>' : 'GIF';
+        btn.innerHTML = (document.querySelector(".fa")) ? '<i class="fa fa-file-video-o"></i>' : 'GIF';
         btn.title = "GIFs";
         bar.appendChild(btn);
         btn.addEventListener("click", e => { e.preventDefault(); open(); }, { capture:true });


### PR DESCRIPTION
## Summary
- align the user count with the chat action bar and push it to the right edge
- reorder chat actions, update the GIF button icon, and ensure the chat tools button sits after GIFs
- adjust avatar message spacing so the first message line sits lower when an avatar is present

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d8575c44d48329b722e63edaf9e59a