### PR TITLE
Fix poll overlay button selector crash

### DIFF
--- a/modules/feature-poll-overlay.js
+++ b/modules/feature-poll-overlay.js
@@ -615,8 +615,22 @@ BTFW.define("feature:poll-overlay", [], async () => {
   function hijackPollButtons() {
     if (buttonObserver) return; // Already watching
 
+    const pollButtonSelector = [
+      'button[onclick*="poll"]',
+      'button[title*="Poll"]',
+      'button[title*="poll"]',
+      '#newpollbtn',
+      '.poll-btn'
+    ].join(', ');
+
     const processButtons = () => {
-      const pollButtons = document.querySelectorAll('button[onclick*="poll"], button[title*="Poll"], button[title*="poll"], #newpollbtn, .poll-btn');
+      let pollButtons;
+      try {
+        pollButtons = document.querySelectorAll(pollButtonSelector);
+      } catch (e) {
+        console.warn('[poll-overlay] Failed to query poll buttons:', e);
+        return;
+      }
       
       pollButtons.forEach(btn => {
         if (btn.dataset.btfwHijacked) return;


### PR DESCRIPTION
## Summary
- add a shared selector string for locating poll buttons in the poll overlay module
- guard the querySelectorAll call so a malformed selector no longer crashes the feature and theme

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d85e29d9ac8329a2229deb1400ea01