### PR TITLE
Allow embedded player alerts to remain clickable

### DIFF
--- a/modules/feature-player.js
+++ b/modules/feature-player.js
@@ -96,9 +96,25 @@ BTFW.define("feature:player", ["feature:layout"], async ({}) => {
 
   function shouldAllowClick(target) {
     if (!target) return false;
-    if (target.closest(".vjs-control-bar,.vjs-control,.vjs-menu,.vjs-menu-content,.vjs-slider,.vjs-volume-panel")) {
+
+    const allowSelectors = [
+      ".vjs-control-bar",
+      ".vjs-control",
+      ".vjs-menu",
+      ".vjs-menu-content",
+      ".vjs-slider",
+      ".vjs-volume-panel",
+      ".vjs-tech .alert",
+      ".vjs-tech [role=\"alert\"]",
+      ".vjs-tech [role=\"dialog\"]",
+      ".vjs-tech .modal",
+      ".vjs-tech .modal-dialog"
+    ].join(",");
+
+    if (target.closest(allowSelectors)) {
       return true;
     }
+
     return false;
   }
 


### PR DESCRIPTION
## Summary
- allow the video.js guard logic to pass through clicks that originate from the embedded player's alert/modal overlays
- ensure the PeerTube privacy warning buttons remain responsive inside the themed player

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9140bdde4832990aa136de662d16b