### PR TITLE
Rebuild poll overlay around native panel

### DIFF
--- a/modules/feature-stack.js
+++ b/modules/feature-stack.js
@@ -25,7 +25,7 @@ BTFW.define("feature:stack", ["feature:layout"], async ({}) => {
     {
       id: "poll-group",
       title: "Polls & Voting",
-      selectors: ["#pollwrap"],
+      selectors: ["#pollwrap", "#btfw-poll-overlay-placeholder"],
       priority: 4
     }
   ];
@@ -630,12 +630,17 @@ BTFW.define("feature:stack", ["feature:layout"], async ({}) => {
       const elements = [];
       group.selectors.forEach(sel => {
         const el = document.querySelector(sel);
-        if (el && 
-            !list.contains(el) && 
-            !el.contains(list) &&
-            !SKIP_SELECTORS.includes(sel)) {
-          elements.push(el);
+        if (!el) return;
+        if (list.contains(el) || el.contains(list)) return;
+        if (SKIP_SELECTORS.includes(sel)) return;
+        if (sel === "#pollwrap") {
+          const overlayState = el.dataset && el.dataset.btfwPollOverlay;
+          const attrState = el.getAttribute && el.getAttribute("data-btfw-poll-overlay");
+          if (overlayState === "video" || attrState === "video") {
+            return;
+          }
         }
+        elements.push(el);
       });
       if (elements.length > 0) {
         groupedElements.set(group.id, { group, elements });


### PR DESCRIPTION
## Summary
- reuse the native poll panel instead of a clone, floating it over the video with an inline overlay shell, launcher, and sidebar placeholder
- honor the theme feature toggle and persist each viewer's overlay preference so the poll can be docked back into the stack or restored over the video on demand
- watch DOM and socket activity to keep the overlay aligned with poll state, returning the panel to the sidebar when polls close and reattaching when new polls arrive

## Testing
- `node -e "const fs=require('fs');const code=fs.readFileSync('modules/feature-poll-overlay.js','utf8');new Function(code);console.log('ok');"`


------
https://chatgpt.com/codex/tasks/task_e_68d9118ad99483299759c1868ecc9949