### PR TITLE
Ensure poll overlay only shows for active polls

### DIFF
--- a/modules/feature-stack.js
+++ b/modules/feature-stack.js
@@ -25,7 +25,7 @@ BTFW.define("feature:stack", ["feature:layout"], async ({}) => {
     {
       id: "poll-group",
       title: "Polls & Voting",
-      selectors: ["#pollwrap", "#btfw-poll-overlay-placeholder"],
+      selectors: ["#pollwrap", "#btfw-poll-parking", "#btfw-poll-history"],
       priority: 4
     }
   ];


### PR DESCRIPTION
## Summary
- ensure the video poll overlay only floats when a poll is active and hide the UI when idle
- add a poll history section under the poll-group stack that archives closed poll results and can be cleared
- move the poll containers into the poll-group stack infrastructure and drop the old placeholder/launcher behaviour

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d930c32e10832982450063b9abf061