### PR TITLE
Style legacy poll well with theme

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -114,6 +114,122 @@ footer {
   box-shadow: 0 10px 24px color-mix(in srgb, var(--btfw-color-danger, #ff4d6d) 38%, transparent 62%);
 }
 
+#pollwrap .well {
+  position: relative;
+  padding: clamp(18px, 4vw, 24px) clamp(16px, 4vw, 24px) clamp(16px, 4vw, 22px);
+  margin: 0;
+  background: linear-gradient(150deg,
+      color-mix(in srgb, var(--btfw-color-panel) 86%, transparent 14%),
+      color-mix(in srgb, var(--btfw-color-surface) 92%, transparent 8%));
+  border-radius: 20px;
+  border: 1px solid color-mix(in srgb, var(--btfw-color-accent) 30%, transparent 70%);
+  box-shadow: 0 18px 48px color-mix(in srgb, var(--btfw-color-bg) 28%, transparent 72%);
+  color: var(--btfw-color-text);
+}
+
+#pollwrap .well h3 {
+  margin: 0 0 14px;
+  font-size: clamp(1.05rem, 2.3vw, 1.25rem);
+  font-weight: 600;
+  letter-spacing: 0.015em;
+  color: color-mix(in srgb, var(--btfw-color-text) 96%, transparent 4%);
+}
+
+#pollwrap .well .option {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  margin-bottom: 10px;
+  background: color-mix(in srgb, var(--btfw-color-surface) 86%, transparent 14%);
+  border-radius: 14px;
+  border: 1px solid color-mix(in srgb, var(--btfw-border) 62%, transparent 38%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  font-weight: 500;
+  color: color-mix(in srgb, var(--btfw-color-text) 90%, transparent 10%);
+  transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+#pollwrap .well .option:last-of-type {
+  margin-bottom: 0;
+}
+
+#pollwrap .well .option.option-selected {
+  background: linear-gradient(140deg,
+      color-mix(in srgb, var(--btfw-color-accent) 32%, transparent 68%),
+      color-mix(in srgb, var(--btfw-color-panel) 92%, transparent 8%));
+  border-color: color-mix(in srgb, var(--btfw-color-accent) 44%, transparent 56%);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--btfw-color-accent) 32%, transparent 68%),
+    0 12px 28px color-mix(in srgb, var(--btfw-color-accent) 24%, transparent 76%);
+  color: color-mix(in srgb, var(--btfw-color-text) 96%, transparent 4%);
+}
+
+#pollwrap .well .option .btn {
+  flex: 0 0 auto;
+  min-width: 42px;
+  justify-content: center;
+  padding: 6px 10px;
+  font-weight: 600;
+  border-radius: 10px;
+  box-shadow: none;
+  background: color-mix(in srgb, var(--btfw-color-accent) 28%, var(--btfw-color-surface) 72%);
+  color: color-mix(in srgb, var(--btfw-color-text) 92%, transparent 8%);
+}
+
+#pollwrap .well .option.option-selected .btn {
+  background: color-mix(in srgb, var(--btfw-color-accent) 70%, var(--btfw-color-surface) 30%);
+  color: var(--btfw-color-on-accent);
+}
+
+#pollwrap .well .option .btn.muted {
+  background: color-mix(in srgb, var(--btfw-color-surface) 78%, transparent 22%);
+  color: color-mix(in srgb, var(--btfw-color-text) 72%, transparent 28%);
+}
+
+#pollwrap .well .close {
+  position: absolute;
+  top: 14px;
+  right: 16px;
+  padding: 6px 10px;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  background: color-mix(in srgb, var(--btfw-color-surface) 86%, transparent 14%);
+  color: color-mix(in srgb, var(--btfw-color-text) 70%, transparent 30%);
+  font-size: 1.1rem;
+  line-height: 1;
+  transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
+}
+
+#pollwrap .well .close:hover {
+  background: color-mix(in srgb, var(--btfw-color-accent) 26%, transparent 74%);
+  color: color-mix(in srgb, var(--btfw-color-on-accent) 92%, transparent 8%);
+  border-color: color-mix(in srgb, var(--btfw-color-accent) 40%, transparent 60%);
+  transform: scale(1.04);
+}
+
+#pollwrap .well .label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 18px;
+  padding: 6px 12px;
+  font-size: 0.82rem;
+  letter-spacing: 0.02em;
+  background: color-mix(in srgb, var(--btfw-color-surface) 82%, transparent 18%);
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--btfw-color-border, var(--btfw-border)) 60%, transparent 40%);
+  color: color-mix(in srgb, var(--btfw-color-text) 82%, transparent 18%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+#pollwrap .well .label::before {
+  content: "\f017";
+  font-family: "Font Awesome 5 Free", "Font Awesome 5 Pro", "Font Awesome 5", "FontAwesome", sans-serif;
+  font-weight: 900;
+  font-size: 0.76rem;
+  opacity: 0.75;
+}
+
 #pollwrap .poll-menu strong {
   font-size: 0.95rem;
   letter-spacing: 0.02em;


### PR DESCRIPTION
## Summary
- restyle the legacy poll well container to match the site's gradient panels
- add themed treatments for poll option rows, selected state, close button, and timestamp badge

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d9711889c48329a7e44f1ab39a4a0b