### PR TITLE
Fix GIF chat button icon to use available Font Awesome style

### DIFF
--- a/modules/feature-chat.js
+++ b/modules/feature-chat.js
@@ -173,7 +173,7 @@ function normalizeChatActionButtons() {
     b.id = "btfw-btn-gif";
     b.className = "button is-dark is-small btfw-chatbtn";
     b.title = "GIFs";
-    b.innerHTML = '<i class="fa-light fa-gif"></i>';
+    b.innerHTML = '<i class="fa-solid fa-video"></i>';
     actions.appendChild(b);
   }
 
@@ -189,9 +189,9 @@ function normalizeChatActionButtons() {
     gifBtn.classList.add("button", "is-dark", "is-small");
     gifBtn.title = gifBtn.title || "GIFs";
 
-    const hasIcon = gifBtn.querySelector("i.fa-light.fa-gif");
+    const hasIcon = gifBtn.querySelector("i.fa-solid.fa-video");
     if (!hasIcon) {
-      gifBtn.innerHTML = '<i class="fa-light fa-gif"></i>';
+      gifBtn.innerHTML = '<i class="fa-solid fa-video"></i>';
     }
   }
 


### PR DESCRIPTION
## Summary
- replace the GIF chat button icon with a Font Awesome solid video icon that ships with the bundled library
- ensure existing GIF buttons without icons are repopulated with the new icon markup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9a415ddbc8329aa247abc35f9cef7