### PR TITLE
Style scrollbars and align chat usercount

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -10,6 +10,43 @@ html, body {
   color: var(--btfw-color-text);
 }
 
+:root {
+  --btfw-scrollbar-track: color-mix(in srgb, var(--btfw-color-bg) 88%, black 12%);
+  --btfw-scrollbar-thumb: color-mix(in srgb, var(--btfw-color-panel) 78%, black 22%);
+  --btfw-scrollbar-thumb-hover: color-mix(in srgb, var(--btfw-color-accent) 32%, var(--btfw-color-panel) 68%);
+  --btfw-scrollbar-thumb-active: color-mix(in srgb, var(--btfw-color-accent) 38%, var(--btfw-color-panel) 62%);
+}
+
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--btfw-scrollbar-thumb) var(--btfw-scrollbar-track);
+}
+
+*::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+*::-webkit-scrollbar-track {
+  background: var(--btfw-scrollbar-track);
+  border-radius: 999px;
+  box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.25);
+}
+
+*::-webkit-scrollbar-thumb {
+  background: var(--btfw-scrollbar-thumb);
+  border-radius: 999px;
+  border: 2px solid color-mix(in srgb, var(--btfw-scrollbar-track) 65%, transparent 35%);
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background: var(--btfw-scrollbar-thumb-hover);
+}
+
+*::-webkit-scrollbar-thumb:active {
+  background: var(--btfw-scrollbar-thumb-active);
+}
+
 body {
   margin: 0;
   font-family: var(--btfw-font-body);

--- a/css/chat.css
+++ b/css/chat.css
@@ -220,6 +220,8 @@
 }
 .btfw-chat-actions #usercount{
   margin-left:auto;
+  order: 100;
+  flex-shrink: 0;
 }
 .button.btfw-chatbtn{ display:inline-flex; align-items:center; gap:6px; }
 

--- a/modules/feature-channel-theme-admin.js
+++ b/modules/feature-channel-theme-admin.js
@@ -1067,6 +1067,10 @@ BTFW.define("feature:channelThemeAdmin", [], async () => {
         (typeof pollFlag === "string" && pollFlag.toLowerCase() === "false")
       );
       root.classList.toggle("btfw-poll-overlay-enabled", enabled);
+      root.classList.toggle("btfw-poll-overlay-disabled", !enabled);
+      document.dispatchEvent(new CustomEvent("btfw:pollOverlay:toggle", {
+        detail: { enabled }
+      }));
     }
     const modules = normalizeModuleUrls(cfg?.resources?.modules || []);
     renderModuleInputs(panel, modules);

--- a/modules/feature-chat.js
+++ b/modules/feature-chat.js
@@ -851,21 +851,29 @@ function watchForStrayButtons(){
 
     const actions = bar.querySelector("#btfw-chat-actions"); if (!actions) return;
 
-    let uc = $("#usercount");
-    if (!uc) uc = Object.assign(document.createElement("div"), { id:"usercount" });
+    const previous = $("#usercount");
+    let existingNum = "0";
+    if (previous) {
+      const text = previous.querySelector(".btfw-usercount-num")
+        ? previous.querySelector(".btfw-usercount-num").textContent
+        : previous.textContent;
+      const match = text && text.match(/\d+/);
+      if (match) existingNum = match[0];
+      previous.remove();
+    }
+
+    const uc = document.createElement("div");
+    uc.id = "usercount";
     uc.classList.add("btfw-usercount");
-
-    const existingText = uc.querySelector(".btfw-usercount-num")
-      ? uc.querySelector(".btfw-usercount-num").textContent
-      : uc.textContent;
-    const existingNum = (existingText && existingText.match(/\d+/))
-      ? existingText.match(/\d+/)[0]
-      : "0";
-
+    uc.setAttribute("role", "status");
+    uc.setAttribute("aria-live", "polite");
     uc.innerHTML = `<i class="fa fa-users" aria-hidden="true"></i>
                     <span class="btfw-usercount-num">${existingNum}</span>`;
+    uc.addEventListener("contextmenu", (ev) => {
+      ev.preventDefault();
+    });
 
-    if (uc.parentElement !== actions) actions.appendChild(uc);
+    actions.appendChild(uc);
 
     orderChatActions(actions);
 

--- a/modules/feature-poll-overlay.js
+++ b/modules/feature-poll-overlay.js
@@ -16,6 +16,10 @@ BTFW.define("feature:poll-overlay", [], async () => {
       display: none;
     }
 
+    :root.btfw-poll-overlay-disabled #btfw-poll-video-overlay {
+      display: none !important;
+    }
+
     #btfw-poll-video-overlay.btfw-poll-active {
       display: block;
     }


### PR DESCRIPTION
## Summary
- add theme-aware custom scrollbar styling with subtle dark tones
- rebuild the chat user count badge to eliminate legacy context menu hooks and pin it flush right
- hook the poll overlay feature toggle into the overlay display via root classes and CSS

## Testing
- not run (not run)

------
https://chatgpt.com/codex/tasks/task_e_68d9a6e8dc94832989a3efdb6f437582