### PR TITLE
Remove poll overlay toggle and fix poll text entities

### DIFF
--- a/modules/feature-channel-theme-admin.js
+++ b/modules/feature-channel-theme-admin.js
@@ -54,9 +54,6 @@ BTFW.define("feature:channelThemeAdmin", [], async () => {
         apiKey: ""
       }
     },
-    features: {
-      videoOverlayPoll: true
-    },
     resources: {
       scripts: [],
       styles: [],
@@ -551,16 +548,12 @@ BTFW.define("feature:channelThemeAdmin", [], async () => {
       normalized.integrations.enabled = true;
     }
 
-    if (!normalized.features || typeof normalized.features !== "object") {
-      normalized.features = cloneDefaults().features;
+    if (normalized.features && typeof normalized.features === "object") {
+      delete normalized.features.videoOverlayPoll;
+      if (Object.keys(normalized.features).length === 0) {
+        delete normalized.features;
+      }
     }
-    const featureFlag = normalized.features?.videoOverlayPoll;
-    normalized.features.videoOverlayPoll = !(
-      featureFlag === false ||
-      featureFlag === 0 ||
-      featureFlag === "0" ||
-      (typeof featureFlag === "string" && featureFlag.toLowerCase() === "false")
-    );
 
     if (!normalized.resources || typeof normalized.resources !== "object") {
       normalized.resources = cloneDefaults().resources;
@@ -795,13 +788,6 @@ BTFW.define("feature:channelThemeAdmin", [], async () => {
               <label for="btfw-theme-slider-json">Featured slider JSON</label>
               <input type="url" id="btfw-theme-slider-json" data-btfw-bind="slider.feedUrl" placeholder="https://example.com/featured.json">
               <p class="help">Paste the URL to the JSON feed used by the channel slider.</p>
-            </div>
-            <div class="field">
-              <label class="btfw-checkbox" for="btfw-theme-feature-poll-overlay">
-                <input type="checkbox" id="btfw-theme-feature-poll-overlay" data-btfw-bind="features.videoOverlayPoll">
-                <span>Enable video poll overlay</span>
-              </label>
-              <p class="help">Shows active polls as an overlay above the video player and replaces the legacy poll creation dialog.</p>
             </div>
             <div class="field">
               <label for="btfw-theme-css-urls">Additional CSS URLs</label>
@@ -1059,18 +1045,8 @@ BTFW.define("feature:channelThemeAdmin", [], async () => {
     });
     const root = document.documentElement;
     if (root) {
-      const pollFlag = cfg?.features?.videoOverlayPoll;
-      const enabled = !(
-        pollFlag === false ||
-        pollFlag === 0 ||
-        pollFlag === "0" ||
-        (typeof pollFlag === "string" && pollFlag.toLowerCase() === "false")
-      );
-      root.classList.toggle("btfw-poll-overlay-enabled", enabled);
-      root.classList.toggle("btfw-poll-overlay-disabled", !enabled);
-      document.dispatchEvent(new CustomEvent("btfw:pollOverlay:toggle", {
-        detail: { enabled }
-      }));
+      root.classList.add("btfw-poll-overlay-enabled");
+      root.classList.remove("btfw-poll-overlay-disabled");
     }
     const modules = normalizeModuleUrls(cfg?.resources?.modules || []);
     renderModuleInputs(panel, modules);
@@ -1129,16 +1105,12 @@ BTFW.define("feature:channelThemeAdmin", [], async () => {
       updated.integrations.tmdb = { apiKey: "" };
     }
     updated.integrations.tmdb.apiKey = (updated.integrations.tmdb.apiKey || "").trim();
-    if (!updated.features || typeof updated.features !== "object") {
-      updated.features = cloneDefaults().features;
+    if (updated.features && typeof updated.features === "object") {
+      delete updated.features.videoOverlayPoll;
+      if (Object.keys(updated.features).length === 0) {
+        delete updated.features;
+      }
     }
-    const updatedFeatureFlag = updated.features?.videoOverlayPoll;
-    updated.features.videoOverlayPoll = !(
-      updatedFeatureFlag === false ||
-      updatedFeatureFlag === 0 ||
-      updatedFeatureFlag === "0" ||
-      (typeof updatedFeatureFlag === "string" && updatedFeatureFlag.toLowerCase() === "false")
-    );
     if (!updated.typography || typeof updated.typography !== "object") {
       updated.typography = cloneDefaults().typography;
     }

--- a/modules/feature-poll-overlay.js
+++ b/modules/feature-poll-overlay.js
@@ -160,6 +160,20 @@ BTFW.define("feature:poll-overlay", [], async () => {
   let userVotes = new Set(); // Track which options user voted for
   let pollSyncInterval = null;
 
+  const ENTITY_DECODER = document.createElement("textarea");
+
+  function decodeHtmlEntities(value) {
+    if (typeof value !== "string") {
+      if (value == null) return "";
+      return String(value);
+    }
+    if (value.length === 0) {
+      return "";
+    }
+    ENTITY_DECODER.innerHTML = value;
+    return ENTITY_DECODER.value;
+  }
+
   function injectCSS() {
     if (document.getElementById(CSS_ID)) return;
     const style = document.createElement("style");
@@ -234,7 +248,7 @@ BTFW.define("feature:poll-overlay", [], async () => {
     const votesSpan = overlay.querySelector(".btfw-poll-votes");
     const endBtn = overlay.querySelector(".btfw-poll-end-btn");
 
-    if (title) title.textContent = poll.title || "Poll";
+    if (title) title.textContent = decodeHtmlEntities(poll.title || "Poll");
     
     // Show/hide end poll button based on permissions
     if (endBtn) {
@@ -253,7 +267,7 @@ BTFW.define("feature:poll-overlay", [], async () => {
         
         const optionText = document.createElement("span");
         optionText.className = "btfw-poll-option-text";
-        optionText.textContent = option;
+        optionText.textContent = decodeHtmlEntities(option);
         
         // Set initial vote count
         const voteCount = poll.votes && poll.votes[index] ? poll.votes[index] : 0;


### PR DESCRIPTION
## Summary
- remove the poll overlay toggle from the channel toolkit and drop the stored feature flag
- always mark the poll overlay as enabled when the toolkit renders
- decode HTML entities in poll overlay titles and options so characters like parentheses render correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9acf9b35483299d1a5ed3ac7cbfd7