### PR TITLE
Improve overlay button alignment and theme settings spacing

### DIFF
--- a/billtube-fw.js
+++ b/billtube-fw.js
@@ -123,6 +123,23 @@
 
   BootOverlay.show();
 
+  function removeLegacyFooter() {
+    const nuke = () => {
+      const legacy = document.getElementById("footer");
+      if (legacy) {
+        legacy.remove();
+      }
+    };
+
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", nuke, { once: true });
+    } else {
+      nuke();
+    }
+  }
+
+  removeLegacyFooter();
+
 function qparam(u, kv){ return u + (u.indexOf('?')>=0?'&':'?') + kv; }
 
 var BTFW_VERSION = (function(){

--- a/css/base.css
+++ b/css/base.css
@@ -1289,11 +1289,12 @@ body:not(.btfw-mobile-stack-enabled) #btfw-stack.btfw-stack--compact .btfw-stack
 }
 
 #btfw-theme-modal .btfw-checkbox{
-  display: inline-flex;
+  display: flex;
   align-items: flex-start;
-  gap: 10px;
+  gap: 12px;
   font-weight: 600;
   color: color-mix(in srgb, var(--btfw-color-text) 82%, transparent 18%);
+  line-height: 1.45;
 }
 
 #btfw-theme-modal .btfw-checkbox input{
@@ -1301,6 +1302,19 @@ body:not(.btfw-mobile-stack-enabled) #btfw-stack.btfw-stack--compact .btfw-stack
   height: 18px;
   accent-color: var(--btfw-color-accent);
   margin-top: 2px;
+  flex-shrink: 0;
+}
+
+#btfw-theme-modal .btfw-checkbox span{
+  display: block;
+  flex: 1 1 auto;
+  margin-top: 1px;
+}
+
+#btfw-theme-modal .btfw-ts-control--radios .radio span{
+  display: inline-block;
+  line-height: 1.4;
+  flex: 1 1 auto;
 }
 
 #btfw-theme-modal .select select{

--- a/css/mobile.css
+++ b/css/mobile.css
@@ -151,8 +151,11 @@ body:not(.btfw-mobile-stack-enabled) #btfw-mobile-stack{ display:none !important
   }
 
   /* Video overlay buttons: keep accessible spacing */
-  #videowrap .btfw-video-overlay .btfw-vo-right{
-    top: 8px; right: 8px; gap: 6px;
+  #videowrap .btfw-video-overlay .btfw-vo-bar{
+    top: 8px; left: 8px; right: 8px; gap: 8px;
+  }
+  #videowrap .btfw-video-overlay .btfw-vo-section{
+    gap: 6px;
   }
   #videowrap .btfw-video-overlay .btfw-vo-btn{
     padding: 6px 8px;

--- a/css/overlays.css
+++ b/css/overlays.css
@@ -128,13 +128,32 @@
   z-index: 1200;
 }
 
-#videowrap .btfw-video-overlay .btfw-vo-right {
+#videowrap .btfw-video-overlay .btfw-vo-bar {
   position: absolute;
   top: 10px;
+  left: 10px;
   right: 10px;
   display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  pointer-events: none;
+  gap: 10px;
+}
+
+#videowrap .btfw-video-overlay .btfw-vo-section {
+  display: flex;
+  flex-wrap: wrap;
   gap: 8px;
   pointer-events: auto;      /* buttons remain clickable */
+}
+
+#videowrap .btfw-video-overlay .btfw-vo-section--left {
+  justify-content: flex-start;
+}
+
+#videowrap .btfw-video-overlay .btfw-vo-section--right {
+  margin-left: auto;
+  justify-content: flex-end;
 }
 
 #videowrap .btfw-video-overlay .btfw-vo-btn {

--- a/css/player.css
+++ b/css/player.css
@@ -458,7 +458,7 @@
   pointer-events: none;
   grid-area: 1 / 1;
 }
-#videowrap .btfw-video-overlay .btfw-vo-right{ pointer-events: auto; }
+#videowrap .btfw-video-overlay .btfw-vo-section{ pointer-events: auto; }
 
 /* Space for modules stacked under the player */
 

--- a/modules/feature-billcaster.js
+++ b/modules/feature-billcaster.js
@@ -126,7 +126,7 @@ $(document).ready(function () {
     var $btn = $(
       '<button id="btfw-vo-cast" ' +
         'class="btn btn-sm btn-default btfw-vo-adopted" ' +
-        'title="Cast to device" data-btfw-overlay="1">' +
+        'title="Cast to device" data-btfw-overlay="1" data-btfw-vo-align="left">' +
         '<span class="glyphicon glyphicon-signal"></span>' +
       '</button>'
     );
@@ -148,7 +148,7 @@ $(document).ready(function () {
     var $btn = $(
       '<button id="btfw-vo-cast-fallback" ' +
         'class="btn btn-sm btn-default btfw-vo-adopted" ' +
-        'title="Casting not available" data-btfw-overlay="1">' +
+        'title="Casting not available" data-btfw-overlay="1" data-btfw-vo-align="left">' +
         '<span class="glyphicon glyphicon-info-sign"></span>' +
       '</button>'
     );

--- a/modules/feature-video-overlay.js
+++ b/modules/feature-video-overlay.js
@@ -57,8 +57,32 @@ BTFW.define("feature:videoOverlay", ["feature:ambient"], async () => {
       }
 
       #btfw-video-overlay .btfw-vo-bar{
-        position:absolute; right:12px; top:12px; display:flex; gap:8px; pointer-events:auto;
+        position:absolute;
+        top:12px;
+        left:12px;
+        right:12px;
+        display:flex;
+        align-items:flex-start;
+        justify-content:space-between;
+        pointer-events:none;
+        gap:12px;
         background:transparent;
+      }
+
+      #btfw-video-overlay .btfw-vo-section{
+        display:flex;
+        flex-wrap:wrap;
+        gap:8px;
+        pointer-events:auto;
+      }
+
+      #btfw-video-overlay .btfw-vo-section--left{
+        justify-content:flex-start;
+      }
+
+      #btfw-video-overlay .btfw-vo-section--right{
+        margin-left:auto;
+        justify-content:flex-end;
       }
 
       #btfw-video-overlay .btfw-vo-btn{
@@ -155,7 +179,12 @@ BTFW.define("feature:videoOverlay", ["feature:ambient"], async () => {
       @media (max-width: 768px) {
         #btfw-video-overlay .btfw-vo-bar {
           top: 8px;
+          left: 8px;
           right: 8px;
+          gap: 8px;
+        }
+
+        #btfw-video-overlay .btfw-vo-section{
           gap: 6px;
         }
 
@@ -169,6 +198,88 @@ BTFW.define("feature:videoOverlay", ["feature:ambient"], async () => {
       }
     `;
     document.head.appendChild(st);
+  }
+
+  const LEFT_ALIGN_IDS = new Set(["btfw-vo-cast", "btfw-vo-cast-fallback", "castButton", "fallbackButton"]);
+
+  function getBarSections(bar) {
+    if (!bar) return null;
+    if (bar._btfwSections) return bar._btfwSections;
+
+    let left = bar.querySelector(".btfw-vo-section--left");
+    let right = bar.querySelector(".btfw-vo-section--right");
+
+    if (!left) {
+      left = document.createElement("div");
+      left.className = "btfw-vo-section btfw-vo-section--left";
+      left.dataset.align = "left";
+      bar.appendChild(left);
+    }
+
+    if (!right) {
+      right = document.createElement("div");
+      right.className = "btfw-vo-section btfw-vo-section--right";
+      right.dataset.align = "right";
+      bar.appendChild(right);
+    }
+
+    const sections = { left, right };
+    bar._btfwSections = sections;
+
+    const initialChildren = Array.from(bar.children).filter(
+      (child) => child !== left && child !== right
+    );
+    if (initialChildren.length) {
+      initialChildren.forEach((child) => routeNodeToSection(bar, child));
+    }
+
+    if (!bar._btfwObserver) {
+      const observer = new MutationObserver((mutations) => {
+        if (bar._btfwRouting) return;
+        mutations.forEach((mutation) => {
+          mutation.addedNodes.forEach((node) => routeNodeToSection(bar, node));
+        });
+      });
+      observer.observe(bar, { childList: true });
+      bar._btfwObserver = observer;
+    }
+
+    return sections;
+  }
+
+  function determineAlignment(node) {
+    if (!node || !(node instanceof HTMLElement)) return "right";
+    const explicit = (node.dataset && node.dataset.btfwVoAlign) || node.getAttribute("data-btfw-vo-align");
+    if (explicit && /^(left|right)$/i.test(explicit)) {
+      return explicit.toLowerCase();
+    }
+    const id = (node.id || "").toLowerCase();
+    return LEFT_ALIGN_IDS.has(id) ? "left" : "right";
+  }
+
+  function placeNodeInBar(bar, node, align = null, { prepend = false } = {}) {
+    if (!bar || !node) return;
+    const sections = getBarSections(bar);
+    if (!sections) return;
+    const targetAlign = (align || determineAlignment(node)) === "left" ? "left" : "right";
+    const target = targetAlign === "left" ? sections.left : sections.right;
+    bar._btfwRouting = true;
+    try {
+      if (prepend) {
+        target.insertBefore(node, target.firstChild || null);
+      } else {
+        target.appendChild(node);
+      }
+      node.setAttribute("data-btfw-vo-align", targetAlign);
+    } finally {
+      bar._btfwRouting = false;
+    }
+  }
+
+  function routeNodeToSection(bar, node) {
+    if (!node || !(node instanceof HTMLElement)) return;
+    if (node.classList && node.classList.contains("btfw-vo-section")) return;
+    placeNodeInBar(bar, node);
   }
 
   function ensureOverlay() {
@@ -189,6 +300,8 @@ BTFW.define("feature:videoOverlay", ["feature:ambient"], async () => {
       bar.id = "btfw-vo-bar";
       overlay.appendChild(bar);
     }
+
+    getBarSections(bar);
 
     setupHoverEffects(wrap, overlay);
     ensureLocalSubsButton(bar);
@@ -332,12 +445,12 @@ BTFW.define("feature:videoOverlay", ["feature:ambient"], async () => {
     const customButtons = [];
 
     if (!document.querySelector("#fullscreenbtn")) {
-      customButtons.push({ id: "btfw-fullscreen", icon: "fas fa-expand", tooltip: "Fullscreen", action: toggleFullscreen });
+      customButtons.push({ id: "btfw-fullscreen", icon: "fas fa-expand", tooltip: "Fullscreen", action: toggleFullscreen, align: "right" });
     }
 
     customButtons.push(
-      { id: "btfw-ambient", icon: "fas fa-sun", tooltip: "Ambient Mode", action: toggleAmbient },
-      { id: "btfw-airplay", icon: "fas fa-cast", tooltip: "AirPlay", action: enableAirplay }
+      { id: "btfw-ambient", icon: "fas fa-sun", tooltip: "Ambient Mode", action: toggleAmbient, align: "right" },
+      { id: "btfw-airplay", icon: "fas fa-cast", tooltip: "AirPlay", action: enableAirplay, align: "right" }
     );
 
     customButtons.forEach((btnConfig) => {
@@ -349,8 +462,8 @@ BTFW.define("feature:videoOverlay", ["feature:ambient"], async () => {
         btn.innerHTML = `<i class="${btnConfig.icon}"></i>`;
         btn.title = btnConfig.tooltip;
         btn.addEventListener("click", btnConfig.action);
-        bar.appendChild(btn);
       }
+      placeNodeInBar(bar, btn, btnConfig.align);
     });
 
     syncAmbientButton();
@@ -363,7 +476,7 @@ BTFW.define("feature:videoOverlay", ["feature:ambient"], async () => {
       if (!el) return;
 
       if (el.dataset.btfwOverlay === "1") {
-        if (el.parentElement !== bar) bar.appendChild(el);
+        placeNodeInBar(bar, el);
         return;
       }
 
@@ -395,7 +508,7 @@ BTFW.define("feature:videoOverlay", ["feature:ambient"], async () => {
         };
       }
 
-      bar.appendChild(el);
+      placeNodeInBar(bar, el);
     });
   }
 
@@ -663,8 +776,8 @@ BTFW.define("feature:videoOverlay", ["feature:ambient"], async () => {
         e.preventDefault();
         pickLocalSubs();
       });
-      bar.prepend(btn);
     }
+    placeNodeInBar(bar, btn, "right", { prepend: true });
     btn.style.display = localSubsEnabled() ? "" : "none";
   }
 


### PR DESCRIPTION
## Summary
- remove the legacy `#footer` element during boot to avoid duplicate footers
- restructure the video overlay bar into left/right sections with alignment helpers for cast and native controls
- refresh Theme Settings checkbox and radio spacing to prevent button text overlap on the video tab

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da6d76530c83299b8c874ad6224623