### PR TITLE
Optimize modal initialization listeners

### DIFF
--- a/modules/feature-modal-skin.js
+++ b/modules/feature-modal-skin.js
@@ -79,22 +79,15 @@ BTFW.define("feature:modal-skin", [], async () => {
     // initial pass
     skinAll();
 
-    // observe new modals being added
-    const mo = new MutationObserver(muts=>{
-      for (const m of muts){
-        m.addedNodes && m.addedNodes.forEach(n=>{
-          if (n.nodeType===1) {
-            if (n.classList?.contains("modal")) decorate(n);
-            else n.querySelectorAll?.(".modal").forEach(decorate);
-          }
-        });
-      }
-    });
-    mo.observe(document.body, {childList:true, subtree:true});
+    const handleBootstrapModal = (event)=>{
+      const modal = event?.target && event.target.classList?.contains("modal")
+        ? event.target
+        : event?.target?.closest?.(".modal");
+      if (modal) decorate(modal);
+    };
 
-    // also re-run after CyTube opens common dialogs the first time
-    setTimeout(skinAll, 400);
-    setTimeout(skinAll, 1000);
+    document.addEventListener("show.bs.modal", handleBootstrapModal, true);
+    document.addEventListener("shown.bs.modal", handleBootstrapModal, true);
   }
 
   if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", boot);


### PR DESCRIPTION
## Summary
- switch modal skinning into Bootstrap modal show/shown events instead of a body-wide observer
- delegate theme settings open triggers and user options decoration to event-based handlers
- initialize the channel theme admin panel when the channel modal actually opens via modal events

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daa034dbb883299c19b5232c89bb72