### PR TITLE
Adjust vertical video height for mobile layout

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -495,7 +495,7 @@ a:hover {
 
 #btfw-grid.btfw-grid--vertical #videowrap iframe,
 #btfw-grid.btfw-grid--vertical #videowrap video{
-  height: auto;
+  height: 100%;
 }
 
 #btfw-grid.btfw-grid--vertical #btfw-chatcol{


### PR DESCRIPTION
## Summary
- ensure the iframe/video elements in vertical grid layouts fill their container by setting their height to 100%

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daa7579d788329808bd6ca20da484f