### PR TITLE
Remove CyTube legacy footer after theme load

### DIFF
--- a/modules/feature-footer.js
+++ b/modules/feature-footer.js
@@ -223,10 +223,19 @@ BTFW.define("feature:footer", [], async () => {
     ensureBrandingBlock();
   }
 
+  function removeLegacyFooter(){
+    document.querySelectorAll("footer#footer").forEach(legacy => {
+      if (legacy && legacy.isConnected) {
+        legacy.remove();
+      }
+    });
+  }
+
   function maintainFooter(){
     ensureStyles();
     moveForms();
     insertBranding();
+    removeLegacyFooter();
   }
 
   function boot(){
@@ -245,9 +254,12 @@ BTFW.define("feature:footer", [], async () => {
     boot();
   }
 
+  document.addEventListener("btfw:ready", () => removeLegacyFooter(), { once: true });
+
   return {
     name: "feature:footer",
     moveForms,
-    insertBranding
+    insertBranding,
+    removeLegacyFooter
   };
 });


### PR DESCRIPTION
## Summary
- remove the legacy CyTube footer element once the BillTube theme finishes booting
- ensure ongoing footer maintenance deletes any re-inserted legacy footer markup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbb1325f10832995b250281c1a2a2f