### PR TITLE
Restore channel slider when only feed URL is set

### DIFF
--- a/modules/feature-channels.js
+++ b/modules/feature-channels.js
@@ -34,6 +34,10 @@ BTFW.define("feature:channels", [], async () => {
         url = window.Channel_JSON || '';
       }
 
+      if (typeof enabled === 'undefined' && url) {
+        enabled = true;
+      }
+
       return { enabled: Boolean(enabled), url: url || '' };
     } catch (_) {
       return { enabled: false, url: '' };


### PR DESCRIPTION
## Summary
- default the featured channel slider to enabled when a feed URL is present but no explicit flag is provided
- prevent the slider from being removed when legacy Channel JS only defines Channel_JSON

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dbb11ab8b08329b3048d0fc3ec8384