### PR TITLE
Reinitialize channel slider after theme updates

### DIFF
--- a/modules/feature-channels.js
+++ b/modules/feature-channels.js
@@ -588,6 +588,17 @@ BTFW.define("feature:channels", [], async () => {
     document.addEventListener('btfw:layoutReady', () => {
       setTimeout(initializeChannels, 300);
     });
+
+    let themeTimer = null;
+    const scheduleThemeSync = () => {
+      if (themeTimer) clearTimeout(themeTimer);
+      themeTimer = setTimeout(() => {
+        themeTimer = null;
+        initializeChannels();
+      }, 120);
+    };
+
+    document.addEventListener('btfw:channelThemeTint', scheduleThemeSync);
   }
 
   if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- re-run the channel slider bootstrap when channel theme updates fire
- debounce the handler so repeated theme tint events do not spam slider rebuilds

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68dbc65c610c832993ae5c7ce91125a6