### PR TITLE
Ensure channel theme applies without page refresh

### DIFF
--- a/modules/feature-channel-theme-admin.js
+++ b/modules/feature-channel-theme-admin.js
@@ -2028,6 +2028,8 @@ function replaceBlock(original, startMarker, endMarker, block){
       } catch (_) {}
     });
 
+    const runtimeConfig = syncRuntimeThemeConfig(mergedConfig) || mergedConfig;
+
     if (status) {
       if (mode === 'manual') {
         status.textContent = "Theme JS & CSS applied. Submitting changes...";
@@ -2037,8 +2039,8 @@ function replaceBlock(original, startMarker, endMarker, block){
         status.dataset.variant = "idle";
       }
     }
-    renderPreview(panel, mergedConfig);
-    return { config: mergedConfig, jsField, cssField };
+    renderPreview(panel, runtimeConfig);
+    return { config: runtimeConfig, jsField, cssField };
   }
 
   function initPanel(modal){


### PR DESCRIPTION
## Summary
- sync the channel theme runtime whenever the Theme admin settings are applied
- reuse the normalized runtime configuration for the in-panel preview so the UI reflects live values immediately

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68de101d4b408329823a4e554a721f22