### PR TITLE
Add chat join notice toggle and align success toast with theme

### DIFF
--- a/css/overlays.css
+++ b/css/overlays.css
@@ -864,11 +864,11 @@ html[data-btfw-theme="dark"] .panel {
 }
 
 .btfw-notice--success{
-  --btfw-notice-bg: color-mix(in srgb, #31ce8f 38%, var(--btfw-color-panel) 62%);
-  --btfw-notice-border: color-mix(in srgb, #31ce8f 48%, var(--btfw-color-accent) 52%);
-  --btfw-notice-accent: color-mix(in srgb, #31ce8f 70%, var(--btfw-color-accent) 30%);
-  --btfw-notice-icon-bg: color-mix(in srgb, #31ce8f 26%, transparent 74%);
-  --btfw-notice-icon-color: color-mix(in srgb, var(--btfw-color-on-accent) 88%, #dff7eb 12%);
+  --btfw-notice-bg: color-mix(in srgb, var(--btfw-color-accent) 24%, transparent 76%);
+  --btfw-notice-border: color-mix(in srgb, var(--btfw-color-accent) 46%, transparent 54%);
+  --btfw-notice-accent: var(--btfw-color-accent);
+  --btfw-notice-icon-bg: color-mix(in srgb, var(--btfw-color-accent) 28%, transparent 72%);
+  --btfw-notice-icon-color: var(--btfw-color-on-accent);
 }
 
 .btfw-notice--warn{

--- a/modules/feature-notify.js
+++ b/modules/feature-notify.js
@@ -13,11 +13,28 @@ BTFW.define("feature:notify", [], async () => {
   }
 
   const LS_ENABLED     = "btfw:notify:enabled";   // "1"|"0"
+  const LS_JOIN_NOTICES= "btfw:chat:joinNotices"; // "1"|"0"
   const MAX_VISIBLE    = 3;
   const DEFAULT_TIMEOUT= 6000;
 
   let enabled = true;
   try { const v = localStorage.getItem(LS_ENABLED); if (v !== null) enabled = v === "1"; } catch(e){}
+
+  let joinNoticesEnabled = true;
+  try {
+    const stored = localStorage.getItem(LS_JOIN_NOTICES);
+    if (stored !== null) joinNoticesEnabled = stored === "1";
+  } catch(_){}
+
+  document.addEventListener("btfw:chat:joinNoticesChanged", (ev)=>{
+    if (!ev || !ev.detail) return;
+    joinNoticesEnabled = !!ev.detail.enabled;
+  });
+
+  document.addEventListener("btfw:themeSettings:apply", (ev)=>{
+    const value = ev?.detail?.values?.joinNotices;
+    if (value != null) joinNoticesEnabled = !!value;
+  });
 
   // ---- container (absolute overlay) ------------------------------------------
   function ensureStack(){
@@ -386,6 +403,7 @@ function startAutoclose(o){
     try {
       socket.on("addUser", (u)=>{
         const name = (u && (u.name || u.un)) ? (u.name || u.un) : "Someone";
+        if (!joinNoticesEnabled) return;
         postOnce("join:"+name, 4000, ()=>{
           api.success({ title: "Joined", html: `<b>${escapeHtml(decodeHtmlEntities(name))}</b> entered the channel`, icon:"👋", timeout: 4500 });
         });

--- a/modules/feature-theme-settings.js
+++ b/modules/feature-theme-settings.js
@@ -9,6 +9,7 @@ BTFW.define("feature:themeSettings", [], async () => {
     avatarsMode : "btfw:chat:avatars",        // "off" | "small" | "big"
     emoteSize   : "btfw:chat:emoteSize",      // "small" | "medium" | "big"
     gifAutoplay : "btfw:chat:gifAutoplay",    // "1" | "0"
+    chatJoinNotices: "btfw:chat:joinNotices", // "1" | "0"
     stackCompact: "btfw:stack:compact",       // "1" | "0"
     localSubs   : "btfw:video:localsubs",     // "1" | "0"
     billcastEnabled: "btfw:billcast:enabled", // "1" | "0"
@@ -175,6 +176,19 @@ BTFW.define("feature:themeSettings", [], async () => {
                     </label>
                   </div>
                 </section>
+
+                <section class="btfw-ts-card">
+                  <header class="btfw-ts-card__header">
+                    <h3>Notifications</h3>
+                    <p>Decide which chat popups show up for you.</p>
+                  </header>
+                  <div class="btfw-ts-card__body">
+                    <label class="checkbox btfw-checkbox">
+                      <input type="checkbox" id="btfw-chat-join-notices"> <span>Show notifications when users join</span>
+                    </label>
+                    <p class="btfw-help">Affects the “Joined” popups triggered by users entering the channel.</p>
+                  </div>
+                </section>
               </div>
             </div>
 
@@ -285,6 +299,7 @@ BTFW.define("feature:themeSettings", [], async () => {
     const chatTextPx  = $("#btfw-chat-textsize", m)?.value || "14";
     const emoteSize   = $("#btfw-emote-size", m)?.value   || "medium";
     const gifAutoOn   = $("#btfw-gif-autoplay", m)?.checked;
+    const joinNoticesOn = $("#btfw-chat-join-notices", m)?.checked;
     const compactBtn  = $("#btfw-compact-stack-toggle", m);
     const compactOn   = compactBtn ? compactBtn.getAttribute("aria-pressed") === "true" : true;
     const localSubsOn = $("#btfw-localsubs-toggle", m)?.checked;
@@ -296,6 +311,7 @@ BTFW.define("feature:themeSettings", [], async () => {
     set(TS_KEYS.chatTextPx, chatTextPx);
     set(TS_KEYS.emoteSize, emoteSize);
     set(TS_KEYS.gifAutoplay, gifAutoOn ? "1":"0");
+    set(TS_KEYS.chatJoinNotices, joinNoticesOn ? "1":"0");
     set(TS_KEYS.stackCompact, compactOn ? "1":"0");
     set(TS_KEYS.localSubs,   localSubsOn ? "1":"0");
     set(TS_KEYS.billcastEnabled, billcastOn ? "1":"0");
@@ -311,6 +327,7 @@ BTFW.define("feature:themeSettings", [], async () => {
 
     // notify modules
     document.dispatchEvent(new CustomEvent("btfw:chat:gifAutoplayChanged", { detail:{ autoplay: !!gifAutoOn } }));
+    document.dispatchEvent(new CustomEvent("btfw:chat:joinNoticesChanged", { detail:{ enabled: !!joinNoticesOn } }));
     document.dispatchEvent(new CustomEvent("btfw:stack:compactChanged",    { detail:{ enabled : !!compactOn } }));
     document.dispatchEvent(new CustomEvent("btfw:video:localsubs:changed", { detail:{ enabled : !!localSubsOn } }));
     document.dispatchEvent(new CustomEvent("btfw:layout:chatSideChanged",   { detail:{ side    : chatSide } }));
@@ -319,6 +336,7 @@ BTFW.define("feature:themeSettings", [], async () => {
         avatarsMode, chatTextPx: parseInt(chatTextPx,10),
         emoteSize, gifAutoplay: !!gifAutoOn, compactStack: !!compactOn,
         localSubs: !!localSubsOn, billcastEnabled: !!billcastOn,
+        joinNotices: !!joinNoticesOn,
         chatSide
       }
     }}));
@@ -348,6 +366,7 @@ BTFW.define("feature:themeSettings", [], async () => {
     if (chatLabel) chatLabel.textContent = `${chatPxNow}px`;
     $("#btfw-emote-size").value   = get(TS_KEYS.emoteSize,   "medium");
     $("#btfw-gif-autoplay").checked = get(TS_KEYS.gifAutoplay, "1") === "1";
+    $("#btfw-chat-join-notices").checked = get(TS_KEYS.chatJoinNotices, "1") === "1";
     $("#btfw-localsubs-toggle").checked = get(TS_KEYS.localSubs, "1") === "1";
     const bc = $("#btfw-billcast-toggle"); if (bc) bc.checked = get(TS_KEYS.billcastEnabled, "1") === "1";
     const compactStored = get(TS_KEYS.stackCompact, "1") === "1";


### PR DESCRIPTION
## Summary
- align the success toast styling with the active theme colors
- add a chat theme setting toggle that lets users hide join notifications
- update the notify feature to respect the saved preference when emitting join toasts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de6f7b88a88329b789c02e4945e019