### PR TITLE
Style guest login bar to match theme

### DIFF
--- a/css/chat.css
+++ b/css/chat.css
@@ -239,6 +239,72 @@
   width:100%;
 }
 
+/* Guest login pill */
+#guestlogin {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 10px 6px 14px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--btfw-border) 64%, transparent 36%);
+  background: color-mix(in srgb, var(--btfw-color-panel) 82%, transparent 18%);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--btfw-color-panel) 90%, transparent 10%),
+              0 10px 24px color-mix(in srgb, var(--btfw-color-bg) 34%, transparent 66%);
+  transition: border-color .2s ease, box-shadow .2s ease, background .2s ease;
+}
+
+#guestlogin:focus-within {
+  border-color: color-mix(in srgb, var(--btfw-color-accent) 52%, transparent 48%);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--btfw-color-accent) 18%, transparent 82%),
+              0 12px 28px color-mix(in srgb, var(--btfw-color-bg) 40%, transparent 60%);
+  background: color-mix(in srgb, var(--btfw-color-panel) 90%, transparent 10%);
+}
+
+#guestlogin .input-group-addon {
+  flex: 0 0 auto;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: color-mix(in srgb, var(--btfw-color-chat-text) 88%, transparent 12%);
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  opacity: 0.85;
+}
+
+#guestlogin .form-control {
+  flex: 1 1 auto;
+  min-width: 0;
+  background: transparent;
+  border: 0;
+  padding: 6px 4px 6px 0;
+  color: var(--btfw-color-chat-text);
+  font-weight: 500;
+  box-shadow: none;
+}
+
+#guestlogin .form-control:focus {
+  outline: none;
+  box-shadow: none;
+}
+
+#guestlogin .form-control::placeholder {
+  color: color-mix(in srgb, var(--btfw-color-chat-text) 62%, transparent 38%);
+  opacity: 1;
+}
+
+@media (max-width: 768px) {
+  #guestlogin {
+    padding: 6px 12px;
+    gap: 8px;
+  }
+
+  #guestlogin .input-group-addon {
+    font-size: 0.7rem;
+  }
+}
+
 /* Bottom action buttons container */
 .btfw-chat-actions{
   display:flex;


### PR DESCRIPTION
## Summary
- restyle the guest login input group to use the chat composer's themed pill treatment
- add focus, placeholder, and responsive tweaks so the guest login blends with the existing UI

## Testing
- not run (CSS-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68deba499e00832994be7a20605ffa26