### PR TITLE
Adjust modal layout and GIF pagination

### DIFF
--- a/css/overlays.css
+++ b/css/overlays.css
@@ -563,7 +563,7 @@
 
 #btfw-gif-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(4, 1fr);
   gap: 12px;
   min-height: 320px;
 }

--- a/modules/feature-bulma-layer.js
+++ b/modules/feature-bulma-layer.js
@@ -120,9 +120,9 @@ html[data-btfw-theme="dark"] .modal-content {
   border:1px solid var(--btfw-border) !important;
 }
 @media screen and (min-width: 769px) {
-    .modal-card, .modal-content {
-        width: 60rem;
-    }
+  .modal-card, .modal-content {
+    width: 44rem;
+  }
 }
 html[data-btfw-theme="dark"] .modal-header,
 html[data-btfw-theme="dark"] .modal-footer {

--- a/modules/feature-gifs.js
+++ b/modules/feature-gifs.js
@@ -1,13 +1,13 @@
 /* BillTube Framework — feature:gifs (BillTube2-compatible, classic GIPHY URL)
    - Inserts GIPHY as https://media1.giphy.com/media/<ID>/giphy.gif  (matches your filter)
    - Inserts Tenor as direct .gif with params stripped
-   - 3×3 grid, search/trending, pagination
+   - 4×3 grid, search/trending, pagination
 */
 
 BTFW.define("feature:gifs", [], async () => {
   const $  = (s, r=document) => r.querySelector(s);
   const $$ = (s, r=document) => Array.from(r.querySelectorAll(s));
-  const PER_PAGE = 9;
+  const PER_PAGE = 12;
 
   /* ---- Keys (BillTube2 defaults; can override via localStorage) ---- */
   const K = { giphy: "btfw:giphy:key", tenor: "btfw:tenor:key" };


### PR DESCRIPTION
## Summary
- decrease the desktop modal width to better match the desired Bulma layout
- expand the GIF browser grid to four columns and paginate 12 items per page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e35c6f098883298350577b7833c08b