### PR TITLE
Ensure theme font stylesheet matches preload credentials

### DIFF
--- a/modules/feature-channel-theme-admin.js
+++ b/modules/feature-channel-theme-admin.js
@@ -679,6 +679,12 @@ background: "#0d0d0d",
         link.rel = "stylesheet";
         document.head.appendChild(link);
       }
+      if (link.rel !== "stylesheet") {
+        link.rel = "stylesheet";
+      }
+      if (link.getAttribute("crossorigin") !== "anonymous") {
+        link.setAttribute("crossorigin", "anonymous");
+      }
       if (link.getAttribute("href") !== url) {
         link.setAttribute("href", url);
       }


### PR DESCRIPTION
## Summary
- ensure the runtime theme font stylesheet keeps the same crossorigin attribute as its preload counterpart so the preloaded response can be reused
- normalize the reused link element to always behave as a stylesheet when updating

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e37659183c832999c957a860c048fd