### PR TITLE
Fix user list overlay scroll behavior

### DIFF
--- a/css/overlays.css
+++ b/css/overlays.css
@@ -75,9 +75,8 @@
   line-height: 1.2;
 }
 #btfw-userlist-pop .btfw-popbody #userlist{
-  max-height: none !important;
-  height: auto !important;
-  overflow: visible !important;
+  max-height: 100% !important;
+  overflow-y: auto !important;
 }
 
 /* The close “X” inside the pop head uses .btfw-popclose */


### PR DESCRIPTION
## Summary
- let the user list inherit the overlay body height so overflow stays scrollable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e382c7a5d083298a74d13414ff145c