### PR TITLE
Theme private message popup

### DIFF
--- a/css/chat.css
+++ b/css/chat.css
@@ -181,6 +181,82 @@
   height: auto;
 }
 
+/* ------------------------------------------------------------------
+   Private message popovers ("PM bar")
+   ------------------------------------------------------------------ */
+.pm-panel {
+  background: color-mix(in srgb, var(--btfw-overlay-bg) 96%, transparent 4%) !important;
+  border: 1px solid var(--btfw-overlay-border) !important;
+  border-radius: calc(var(--btfw-radius, 14px) + 2px);
+  box-shadow: var(--btfw-overlay-shadow);
+  color: var(--btfw-color-text);
+  overflow: hidden;
+  min-width: clamp(260px, 32vw, 360px);
+}
+
+.pm-panel .panel-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px 14px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  background:
+    linear-gradient(135deg,
+      color-mix(in srgb, var(--btfw-color-panel) 88%, transparent 12%),
+      color-mix(in srgb, var(--btfw-color-accent) 18%, transparent 82%)) !important;
+  color: var(--btfw-color-text) !important;
+  border-bottom: 1px solid color-mix(in srgb, var(--btfw-color-accent) 22%, transparent 78%);
+}
+
+.pm-panel .panel-heading .close {
+  float: none;
+  margin-left: auto;
+  color: color-mix(in srgb, var(--btfw-color-text) 72%, transparent 28%);
+  opacity: 1;
+  transition: color 0.18s ease;
+}
+
+.pm-panel .panel-heading .close:hover,
+.pm-panel .panel-heading .close:focus {
+  color: var(--btfw-color-text);
+  text-shadow: none;
+}
+
+.pm-panel .panel-body {
+  padding: 12px 14px 14px;
+  background: color-mix(in srgb, var(--btfw-overlay-elevated) 92%, transparent 8%);
+  color: inherit;
+}
+
+.pm-panel .pm-buffer {
+  max-height: 220px;
+  overflow-y: auto;
+  padding-right: 4px;
+  margin: 0 -4px 8px 0;
+}
+
+.pm-panel hr {
+  margin: 10px 0 12px;
+  border-color: color-mix(in srgb, var(--btfw-color-text) 16%, transparent 84%);
+}
+
+.pm-panel .pm-input {
+  background: color-mix(in srgb, var(--btfw-color-surface) 88%, transparent 12%);
+  border: 1px solid color-mix(in srgb, var(--btfw-color-accent) 20%, transparent 80%);
+  border-radius: var(--btfw-radius, 12px);
+  color: var(--btfw-color-text);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--btfw-color-bg) 55%, transparent 45%);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.pm-panel .pm-input:focus {
+  outline: none;
+  border-color: color-mix(in srgb, var(--btfw-color-accent) 44%, transparent 56%);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--btfw-color-accent) 24%, transparent 76%);
+}
+
 /* Controls row sits below messages, stays visible */
 .btfw-controls-row{
   display:flex;


### PR DESCRIPTION
## Summary
- restyle the private message panel to match the new theme colors and typography
- update the panel header, body, and input states with overlay gradients, borders, and focus treatments

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3e186c7cc8329adf0aa0958483d20