### PR TITLE
Update chat message formatting via socket-driven grouping

### DIFF
--- a/css/chat.css
+++ b/css/chat.css
@@ -2,6 +2,90 @@
 #messagebuffer > div {
   content-visibility: auto;
   contain-intrinsic-size: auto 60px; /* Estimated height for layout calculations */
+  position: relative;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+#messagebuffer > div[class^="chat-msg-"],
+#messagebuffer > div[class*=" chat-msg-"] {
+  display: block !important;
+  padding: 2px 16px !important;
+  padding-left: 72px !important;
+  position: relative;
+  min-height: 22px;
+}
+
+.btfw-new-user-msg {
+  margin-top: 16px !important;
+  padding-top: 4px !important;
+}
+
+.btfw-new-user-msg:first-child {
+  margin-top: 4px !important;
+}
+
+.btfw-continuation-msg {
+  margin-top: 0 !important;
+  padding-top: 0 !important;
+}
+
+#messagebuffer .btfw-chat-avatarwrap {
+  position: absolute;
+  left: 16px;
+  top: 4px;
+  margin: 0 !important;
+}
+
+.btfw-continuation-msg .btfw-chat-avatarwrap {
+  display: none !important;
+}
+
+#messagebuffer .timestamp {
+  position: absolute;
+  right: 16px;
+  top: 4px;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.3) !important;
+  opacity: 0;
+  transition: opacity 0.1s;
+}
+
+#messagebuffer > div:hover .timestamp {
+  opacity: 1;
+}
+
+#messagebuffer > div > span:has(.username) {
+  display: block;
+  line-height: 1.375rem;
+  margin-bottom: 0;
+}
+
+.btfw-continuation-msg > span:has(.username) {
+  display: none !important;
+}
+
+#messagebuffer .username {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+#messagebuffer > div > span:last-child {
+  display: block;
+  line-height: 1.375rem;
+  word-wrap: break-word;
+  margin-top: 0;
+}
+
+#messagebuffer img.channel-emote,
+#messagebuffer img.chat-picture {
+  display: block !important;
+  margin: 4px 0;
+  max-width: 100%;
+}
+
+#messagebuffer > div:hover {
+  background: rgba(255, 255, 255, 0.03);
 }
 
 #messagebuffer .btfw-chat-avatar {
@@ -103,71 +187,6 @@
   /* Ensure smooth scrolling */
   scroll-behavior: smooth;
   -webkit-overflow-scrolling: touch;
-}
-
-#messagebuffer > div { 
-  display: flex;
-  flex-wrap: nowrap;
-  align-items: flex-start;
-  gap: 8px;
-  padding: 4px 10px;
-  position: relative;
-  width: 100%;
-  box-sizing: border-box;
-}
-
-/* Ensure chat messages without avatars keep username spacing */
-#messagebuffer > div[class^="chat-msg-"]:not(.btfw-has-avatar),
-#messagebuffer > div[class*=" chat-msg-"]:not(.btfw-has-avatar) {
-  padding: 4px 10px 0px 30px !important;
-}
-
-#messagebuffer > div .timestamp {
-  order: 3;
-  margin-left: auto !important;
-  display: inline-flex;
-  align-items: center;
-  justify-content: flex-end;
-  flex: 0 0 auto;
-  text-align: right;
-  min-width: max-content;
-  white-space: nowrap;
-  opacity: .65;
-  font-size: 0.8em;
-  padding-left: 12px;
-  color: color-mix(in srgb, var(--btfw-color-chat-text) 70%, transparent 30%);
-}
-
-#messagebuffer > div span.timestamp ~ span {
-  order: 2;
-  display: inline-flex;
-  align-items: flex-start;
-  gap: 6px;
-  flex: 0 0 auto;
-}
-
-#messagebuffer > div span.timestamp + span {
-  flex-wrap: nowrap;
-}
-
-#messagebuffer > div span.timestamp ~ span:last-child {
-  flex: 1 1 auto;
-  min-width: 0;
-  word-break: break-word;
-}
-
-#messagebuffer > div.btfw-has-avatar span.timestamp + span {
-  align-items: center;
-}
-
-#messagebuffer > div.btfw-has-avatar span.timestamp + span + span {
-  margin-top: 10px;
-}
-
-#messagebuffer > div span .username,
-#messagebuffer > div span .nick,
-#messagebuffer > div span .name {
-  font-weight: 600;
 }
 
 #messagebuffer > div.server-msg,


### PR DESCRIPTION
## Summary
- add scoped chat CSS to style new and continuation messages, avatars, timestamps, and hover states
- group chat messages using socket-driven processing with theme reapply hooks instead of mutation observers

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e4ad98444c83299348144c28134c94