### PR TITLE
Set chat GIF dimensions to auto

### DIFF
--- a/css/chat.css
+++ b/css/chat.css
@@ -849,8 +849,8 @@ img.twemoji { width: 1em; height: 1em; vertical-align: -0.15em; }
 #messagebuffer img.channel-emote,
 #messagebuffer img.giphy.chat-picture,
 #messagebuffer img.tenor.chat-picture {
-  width: var(--btfw-emote-size) !important;
-  height: var(--btfw-emote-size) !important;
+  width: auto !important;
+  height: auto !important;
   max-width: var(--btfw-emote-size) !important;
   max-height: var(--btfw-emote-size) !important;
   object-fit: contain;


### PR DESCRIPTION
## Summary
- update chat GIF and emote styling to use automatic width and height while preserving existing max size constraints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4b7684c708329a5494a27711213ab