### PR TITLE
Update chat GIF runtime sizing

### DIFF
--- a/css/chat.css
+++ b/css/chat.css
@@ -849,8 +849,8 @@ img.twemoji { width: 1em; height: 1em; vertical-align: -0.15em; }
 #messagebuffer img.channel-emote,
 #messagebuffer img.giphy.chat-picture,
 #messagebuffer img.tenor.chat-picture {
-  width: var(--btfw-emote-size) !important;
-  height: var(--btfw-emote-size) !important;
+  width: auto !important;
+  height: auto !important;
   max-width: var(--btfw-emote-size) !important;
   max-height: var(--btfw-emote-size) !important;
   object-fit: contain;

--- a/modules/feature-chat-media.js
+++ b/modules/feature-chat-media.js
@@ -54,8 +54,8 @@ BTFW.define("feature:chatMedia", [], async () => {
     if (img.hasAttribute("height")) img.removeAttribute("height");
     // enforce via inline style with !important so nothing overrides it
     const v = "var(--btfw-emote-size)";
-    img.style.setProperty("width",     v, "important");
-    img.style.setProperty("height",    v, "important");
+    img.style.setProperty("width",     "auto", "important");
+    img.style.setProperty("height",    "auto", "important");
     img.style.setProperty("max-width", v, "important");
     img.style.setProperty("max-height",v, "important");
     img.style.setProperty("object-fit","contain");


### PR DESCRIPTION
## Summary
- update the chat media runtime styling to use auto width and height for GIFs while preserving max size constraints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4b7684c708329a5494a27711213ab