### PR TITLE
Improve GIF modal loading feedback

### DIFF
--- a/css/overlays.css
+++ b/css/overlays.css
@@ -567,7 +567,7 @@
   min-height: 320px;
 }
 
-.btfw-gif-cell {
+.btfw-gif-cell { 
   position: relative;
   aspect-ratio: 1 / 1;        /* square */
   border-radius: 12px;
@@ -579,6 +579,33 @@
 }
 .btfw-gif-cell:hover { outline: 2px solid color-mix(in srgb, var(--btfw-color-accent) 56%, transparent 44%); }
 .btfw-gif-cell.is-broken { background: color-mix(in srgb, #ff6f96 70%, transparent 30%); }
+
+.btfw-gif-cell.is-loading::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.68);
+  pointer-events: none;
+}
+
+.btfw-gif-cell.is-loading::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 28px;
+  height: 28px;
+  margin: -14px 0 0 -14px;
+  border-radius: 50%;
+  border: 3px solid color-mix(in srgb, var(--btfw-color-accent) 68%, transparent 32%);
+  border-top-color: var(--btfw-color-on-accent);
+  animation: btfw-spin 0.9s linear infinite;
+  pointer-events: none;
+}
+
+.btfw-gif-cell.is-loading img {
+  filter: brightness(0.55);
+}
 
 .btfw-gif-cell img {
   width: 100%; height: 100%;


### PR DESCRIPTION
## Summary
- add per-cell loading state with spinner overlay and dimmed GIF previews to clarify pagination transitions
- reuse the same image lifecycle helper for new and updated cells to clear loading once the asset is ready
- focus the GIF search field automatically when the modal opens for quicker searches

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4c0e399548329b14176c38ddd475a