### PR TITLE
Refine chat usercount display and socket updates

### DIFF
--- a/css/chat.css
+++ b/css/chat.css
@@ -919,19 +919,28 @@ body.btfw-ts-hide #messagebuffer .timestamp { display:none !important; }
 }
 
 #usercount.btfw-usercount {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    font-size: 12px;
-    opacity: .9;
-    margin-right: auto;
-    padding-left: 12px;
-    color: 
- color-mix(in srgb, var(--btfw-color-chat-text) 86%, transparent 14%);
-    justify-content: flex-end;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  opacity: .9;
+  margin-left: auto;
+  padding: 6px 12px;
+  background: transparent;
+  border: 0;
+  color: color-mix(in srgb, var(--btfw-color-chat-text) 86%, transparent 14%);
+  cursor: pointer;
+  transition: opacity 0.15s ease;
 }
 
-#usercount .fa-users{ font-size:14px; opacity:.75; }
+#usercount.btfw-usercount:hover {
+  opacity: 1;
+}
+
+#usercount .fa-users {
+  font-size: 14px;
+  opacity: .75;
+}
 .server-msg-reconnect {
   border: 0px solid #009900!important;
   border-radius: 10px;

--- a/modules/feature-chat.js
+++ b/modules/feature-chat.js
@@ -1172,299 +1172,82 @@ const scheduleNormalizeChatActions = (() => {
     };
   })();
 
-  /* ---------------- Usercount to bottom-right & remove #chatheader ---------------- */
+  /* ---------------- Custom usercount (icon + number only) ---------------- */
   function ensureUsercountInBar(){
-    const cw  = $("#chatwrap"); if (!cw) return;
+    const cw = $("#chatwrap"); if (!cw) return;
     const bar = cw.querySelector(".btfw-chat-bottombar"); if (!bar) return;
-
     const actions = bar.querySelector("#btfw-chat-actions"); if (!actions) return;
 
-    const previous = $("#usercount");
-    let existingNum = "0";
-    if (previous) {
-      const text = previous.querySelector(".btfw-usercount-num")
-        ? previous.querySelector(".btfw-usercount-num").textContent
-        : previous.textContent;
-      const match = text && text.match(/\d+/);
-      if (match) existingNum = match[0];
-      previous.remove();
-    }
-
-    const uc = document.createElement("div");
-    uc.id = "usercount";
-    uc.classList.add("btfw-usercount");
-    uc.setAttribute("role", "status");
-    uc.setAttribute("aria-live", "polite");
-    uc.innerHTML = `<i class="fa fa-users" aria-hidden="true"></i>
-                    <span class="btfw-usercount-num">${existingNum}</span>`;
-    uc.addEventListener("contextmenu", (ev) => {
-      ev.preventDefault();
-    });
-
-    actions.appendChild(uc);
-
-    orderChatActions(actions);
-
+    // Remove native elements
+    const nativeUc = $("#usercount");
+    if (nativeUc && !nativeUc.classList.contains("btfw-usercount")) nativeUc.remove();
     const ch = $("#chatheader");
     if (ch) ch.remove();
 
-    sanitizeUsercountMarkup();
-    observeUsercountElement();
-    updateUsercount();
-    wireUsercountUpdatesOnce();
-  }
-  let trackedUsercount = null;
-  let latestSocketUsercount = null;
-  let usercountBootstrapTimer = null;
-  let usercountMarkupGuard = false;
+    // Create our usercount button
+    let uc = actions.querySelector("#usercount.btfw-usercount");
+    if (!uc) {
+      uc = document.createElement("button");
+      uc.id = "usercount";
+      uc.classList.add("btfw-usercount");
+      uc.innerHTML = `<i class="fa fa-users" aria-hidden="true"></i>
+                    <span class="btfw-usercount-num">0</span>`;
+      actions.appendChild(uc);
 
-  function ensureUsercountStructure(){
-    const uc = $("#usercount");
-    if (!uc) return null;
-    if (usercountMarkupGuard) return uc.querySelector?.(".btfw-usercount-num") || null;
-    usercountMarkupGuard = true;
-
-    uc.classList.add("btfw-usercount");
-
-    let icon = uc.querySelector?.(".fa.fa-users");
-    if (!icon) {
-      icon = document.createElement("i");
-      icon.className = "fa fa-users";
-      icon.setAttribute("aria-hidden", "true");
-      uc.insertBefore(icon, uc.firstChild || null);
+      // Click toggles userlist
+      uc.addEventListener("click", toggleUserlist);
     }
 
-    let numEl = uc.querySelector?.(".btfw-usercount-num");
-    if (!numEl) {
-      numEl = document.createElement("span");
-      numEl.className = "btfw-usercount-num";
-      uc.appendChild(numEl);
-    }
-
-    Array.from(uc.childNodes).forEach((node) => {
-      if (node === icon || node === numEl) return;
-      if (node.nodeType === Node.TEXT_NODE && !node.textContent.trim()) return;
-      uc.removeChild(node);
-    });
-
-    usercountMarkupGuard = false;
-    return numEl;
+    setUsercount(currentCount);
+    orderChatActions(actions);
+    wireUsercountSocket();
   }
 
-  function sanitizeUsercountMarkup(){
-    const numEl = ensureUsercountStructure();
-    if (numEl && typeof trackedUsercount === "number") {
-      numEl.textContent = String(trackedUsercount);
-    }
+  // Track current count
+  let currentCount = 0;
+
+  function setUsercount(count) {
+    const safe = Number.isFinite(count) ? count : Number(count);
+    const normalized = Math.max(0, Number.isFinite(safe) ? Math.floor(safe) : 0);
+    currentCount = normalized;
+    const numEl = $("#usercount .btfw-usercount-num");
+    if (numEl) numEl.textContent = String(normalized);
   }
 
-  function deriveUsercountFromDom(){
-    const ul = $("#userlist");
-    if (ul) {
-      let els = ul.querySelectorAll("li");
-      if (!els.length) els = ul.querySelectorAll(".userlist_item, .nick, .user");
-      if (els.length) return els.length;
-    }
-    const uc = $("#usercount");
-    const m  = uc && uc.textContent && uc.textContent.match(/\d+/);
-    if (m) return parseInt(m[0], 10) || 0;
-    return 0;
-  }
+  // Wire socket listeners once
+  function wireUsercountSocket() {
+    if (document._btfw_uc_socket_wired) return;
+    document._btfw_uc_socket_wired = true;
 
-  function deriveUsercountFromGlobals(){
-    const candidates = [];
-
-    const USERLIST = window.USERLIST;
-    if (USERLIST) {
-      if (Array.isArray(USERLIST.users)) candidates.push(USERLIST.users.length);
-      if (Array.isArray(USERLIST.userlist)) candidates.push(USERLIST.userlist.length);
-      if (typeof USERLIST.count === "number") candidates.push(USERLIST.count);
-    }
-
-    const CHANNEL = window.CHANNEL;
-    if (CHANNEL) {
-      if (Array.isArray(CHANNEL.users)) candidates.push(CHANNEL.users.length);
-      if (typeof CHANNEL.usercount === "number") candidates.push(CHANNEL.usercount);
-      if (typeof CHANNEL.userCount === "number") candidates.push(CHANNEL.userCount);
-    }
-
-    const CLIENT = window.CLIENT;
-    if (CLIENT) {
-      if (Array.isArray(CLIENT.userlist)) candidates.push(CLIENT.userlist.length);
-      if (typeof CLIENT.getUsercount === "function") {
-        try {
-          const val = CLIENT.getUsercount();
-          if (typeof val === "number") candidates.push(val);
-        } catch (_) {}
-      }
-    }
-
-    if (candidates.length) {
-      for (const val of candidates) {
-        if (typeof val === "number" && Number.isFinite(val) && val >= 0) {
-          return val;
-        }
-      }
-    }
-
-    return null;
-  }
-
-  function derivePreferredUsercount(){
-    if (typeof latestSocketUsercount === "number") {
-      return { count: latestSocketUsercount, source: "socket" };
-    }
-    const globalCount = deriveUsercountFromGlobals();
-    if (typeof globalCount === "number") {
-      return { count: globalCount, source: "global" };
-    }
-    return { count: deriveUsercountFromDom(), source: "dom" };
-  }
-
-  function renderUsercount(count){
-    const numEl = ensureUsercountStructure();
-    if (numEl) numEl.textContent = String(count);
-  }
-
-  function setTrackedUsercount(next, source){
-    const sanitized = Math.max(0, Number.isFinite(next) ? Math.floor(next) : 0);
-    trackedUsercount = sanitized;
-    if (source === "socket") {
-      latestSocketUsercount = sanitized;
-    }
-    renderUsercount(sanitized);
-  }
-  function currentUsercount(){
-    if (typeof trackedUsercount === "number") return trackedUsercount;
-    const { count, source } = derivePreferredUsercount();
-    setTrackedUsercount(count, source);
-    return count;
-  }
-  function updateUsercount(explicit){
-    if (typeof explicit === "number" && !Number.isNaN(explicit)) {
-      setTrackedUsercount(explicit);
-      return;
-    }
-    const { count, source } = derivePreferredUsercount();
-    setTrackedUsercount(count, source);
-  }
-  function adjustUsercount(delta){
-    const next = currentUsercount() + delta;
-    setTrackedUsercount(next, "socket");
-  }
-  function countFromPayload(payload){
-    if (typeof payload === "number" && Number.isFinite(payload)) {
-      return payload;
-    }
-    if (Array.isArray(payload)) {
-      return payload.length;
-    }
-    if (!payload || typeof payload !== "object") {
-      return null;
-    }
-    if (Array.isArray(payload.users)) return payload.users.length;
-    if (Array.isArray(payload.list)) return payload.list.length;
-    if (Array.isArray(payload.viewers)) return payload.viewers.length;
-    if (Array.isArray(payload.connections)) return payload.connections.length;
-    if (typeof payload.usercount === "number") return payload.usercount;
-    if (typeof payload.userCount === "number") return payload.userCount;
-    if (typeof payload.viewerCount === "number") return payload.viewerCount;
-    if (typeof payload.count === "number") return payload.count;
-    if (typeof payload.length === "number") return payload.length;
-    return null;
-  }
-
-  function observeUsercountElement(){
-    const uc = $("#usercount");
-    if (!uc || uc._btfwUsercountMO) return;
-    const mo = new MutationObserver(() => {
-      sanitizeUsercountMarkup();
-    });
-    mo.observe(uc, { childList: true, subtree: false, characterData: true });
-    uc._btfwUsercountMO = mo;
-  }
-
-  function observeUserlistDom(){
-    const ul = $("#userlist");
-    if (!ul || ul._btfwUsercountMO) return false;
-    const mo = new MutationObserver(() => {
-      updateUsercount();
-    });
-    mo.observe(ul, { childList: true });
-    ul._btfwUsercountMO = mo;
-    updateUsercount();
-    return true;
-  }
-
-  function scheduleUserlistObserver(){
-    if (document._btfwUserlistObserverScheduled) return;
-    document._btfwUserlistObserverScheduled = true;
-    let tries = 0;
-    const attempt = () => {
-      observeUsercountElement();
-      const attached = observeUserlistDom();
-      tries++;
-      if (attached || tries > 40) {
+    const tryWire = () => {
+      if (!window.socket || typeof window.socket.on !== "function") {
+        setTimeout(tryWire, 500);
         return;
       }
-      setTimeout(attempt, 250);
+
+      // Server sends usercount every 10s (throttled)
+      socket.on("usercount", (count) => {
+        setUsercount(count);
+      });
+
+      // Immediate updates
+      socket.on("addUser", () => {
+        setUsercount(currentCount + 1);
+      });
+
+      socket.on("userLeave", () => {
+        setUsercount(Math.max(0, currentCount - 1));
+      });
+
+      // Full userlist refresh
+      socket.on("userlist", (list) => {
+        if (Array.isArray(list)) {
+          setUsercount(list.length);
+        }
+      });
     };
-    attempt();
-  }
 
-  function wireUsercountUpdatesOnce(){
-    if (document._btfw_uc_wired) return;
-    document._btfw_uc_wired = true;
-
-    scheduleUserlistObserver();
-
-    if (window.socket && typeof window.socket.on === "function") {
-      try {
-        const safeOn = (event, handler) => {
-          try {
-            socket.on(event, handler);
-          } catch (_) {}
-        };
-
-        safeOn("addUser",   () => adjustUsercount(1));
-        safeOn("userLeave", () => adjustUsercount(-1));
-        safeOn("userlist",  (payload) => {
-          const count = countFromPayload(payload);
-          if (typeof count === "number") {
-            setTrackedUsercount(count, "socket");
-          } else {
-            updateUsercount();
-          }
-        });
-        ["usercount", "updateUsercount", "viewerCount", "channelUsercount"].forEach((event) => {
-          safeOn(event, (payload) => {
-            const count = countFromPayload(payload);
-            if (typeof count === "number") {
-              setTrackedUsercount(count, "socket");
-            }
-          });
-        });
-      } catch (_) {}
-    }
-
-    if (!usercountBootstrapTimer) {
-      let attempts = 0;
-      usercountBootstrapTimer = setInterval(() => {
-        attempts++;
-        const { count, source } = derivePreferredUsercount();
-        if (typeof count === "number") {
-          setTrackedUsercount(count, source);
-          if (source === "socket" || attempts > 20) {
-            clearInterval(usercountBootstrapTimer);
-            usercountBootstrapTimer = null;
-          }
-        }
-        if (attempts > 40) {
-          clearInterval(usercountBootstrapTimer);
-          usercountBootstrapTimer = null;
-        }
-      }, 500);
-    }
+    tryWire();
   }
 
   /* ---------------- Deterministic username colors ---------------- */


### PR DESCRIPTION
## Summary
- replace the legacy usercount DOM/watch logic with a dedicated button that wires socket updates
- sanitize and display the usercount inline with the chat action bar, removing redundant native elements
- refresh the usercount button styling to match the icon-plus-number design and hover behavior

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4e9d45ab48329ae596521dd52d3bc