### PR TITLE
Clean up chat usercount label text and add icon

### DIFF
--- a/css/chat.css
+++ b/css/chat.css
@@ -919,7 +919,7 @@ body.btfw-ts-hide #messagebuffer .timestamp { display:none !important; }
 }
 
 #usercount.btfw-usercount {
-    display: flex;
+    display: inline-flex;
     align-items: center;
     gap: 6px;
     font-size: 12px;
@@ -938,9 +938,13 @@ body.btfw-ts-hide #messagebuffer .timestamp { display:none !important; }
   opacity: 1;
 }
 
-#usercount .fa-users {
+#usercount.btfw-usercount::before {
+  content: "\f0c0";
+  font-family: "Font Awesome 5 Free", "Font Awesome 5 Pro", "Font Awesome 5", "FontAwesome", sans-serif;
+  font-weight: 900;
   font-size: 14px;
   opacity: .75;
+  line-height: 1;
 }
 .server-msg-reconnect {
   border: 0px solid #009900!important;


### PR DESCRIPTION
## Summary
- strip the server-provided "connected user" text from the chat usercount and reuse the existing element in the action bar
- rewire the socket listeners so the cleaned count stays updated and keeps toggling the user list
- add CSS to inject a user icon before the usercount via a pseudo-element

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4f5b4d6548329a11a763b9f547db1